### PR TITLE
fix: respect per-agent thinking level instead of forcing global reasoningLevel

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2322,7 +2322,11 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	let desiredThinkingLevel: any;
 
 	function captureDesiredThinking() {
-		desiredThinkingLevel = config.reasoningLevel;
+		// Capture the session's ACTUAL thinking level (the per-agent configured value,
+		// e.g. Mimir=low, Brokkr=high) rather than the global config.reasoningLevel.
+		// Using the global default here clobbered per-agent thinking on every agent_start.
+		// This still preserves the level across failovers via restoreDesiredThinking.
+		desiredThinkingLevel = (pi as any).getThinkingLevel?.() ?? config.reasoningLevel;
 		try {
 			(pi as any).setThinkingLevel?.(desiredThinkingLevel);
 		} catch {


### PR DESCRIPTION
## Problem

`captureDesiredThinking()` runs on every `agent_start` and calls `setThinkingLevel(config.reasoningLevel)`. `reasoningLevel` is a single **global** value (defaults to `"high"`, and the config parser falls back to `"high"` for any unset/invalid value, so it can't be disabled).

The result: per-agent thinking levels are clobbered on the first turn of every session. A delegated agent configured for `low` thinking is forced to `high` as soon as its first turn starts.

Observed in practice with per-agent configs (e.g. an orchestrator on `high` delegating to agents configured `low`): the spawned agent's session records `thinking_level_change: low -> high` *before the first user message* — i.e. `agent_start` overrides the configured level.

The code's stated intent (per the existing comment) is to preserve the user's thinking level across account failovers so it doesn't "drift downward." But capturing the static global `config.reasoningLevel` — rather than the session's actual level — defeats per-agent configuration.

## Fix

Capture the session's **actual** thinking level via `pi.getThinkingLevel()` (the per-agent value set through `--thinking`), falling back to `config.reasoningLevel` only if it's unavailable:

```ts
desiredThinkingLevel = (pi as any).getThinkingLevel?.() ?? config.reasoningLevel;
```

This still preserves the level across failovers (the original intent — `restoreDesiredThinking()` re-asserts `desiredThinkingLevel` after a model switch), but no longer overrides per-agent thinking on `agent_start`.

## Verification

- A session started with `--thinking low` now stays `low`: `agent_start` fires but produces **no** `thinking_level_change` to `high`. Before the change, the identical session flipped `low -> high` on its first turn.
- `npm run check` (`tsc --noEmit`) passes.
- Full test suite passes (`npm test`: 126/126).