### PR TITLE
fix: seed Codex alias catalogs before scope resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Persisted Codex model catalogs now seed numbered account aliases during startup, before Pi
+  resolves saved scoped models. Empty catalogs and disabled model discovery continue to use the
+  host/static fallback instead.
+
 ## [1.14.3] - 2026-08-02
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -2742,7 +2742,11 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		// authoritative for that specific account.
 		for (const provider of registeredSlots) {
 			if (classifyProvider(provider, config.qwenProvider) !== "openai-codex") continue;
-			if (codexModelCatalogByProvider.has(provider)) continue;
+			if (
+				config.autoDiscoverModels &&
+				codexModelCatalogByProvider.get(provider)?.models.length
+			)
+				continue;
 			registerCodexCatalog(pi, provider, merged as Array<Record<string, unknown>>);
 		}
 	}
@@ -2830,7 +2834,8 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		discoveredCodexModelOrder = allKnown.map((model) => model.id);
 
 		for (const provider of providers) {
-			const models = codexModelCatalogByProvider.get(provider)?.models ?? registryFallback;
+			const cached = codexModelCatalogByProvider.get(provider)?.models;
+			const models = cached?.length ? cached : registryFallback;
 			registerCodexCatalog(pi, provider, models as Array<Record<string, unknown>>);
 		}
 		// Also keep unauthenticated spare login slots current so a newly logged-in account can select
@@ -3594,8 +3599,16 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 				if (index <= 1) continue; // base provider is native
 				if (registeredSlots.has(id)) continue;
 				if (family === "anthropic") registerAnthropicSlot(pi, id);
-				else if (family === "openai-codex") registerCodexSlot(pi, id);
-				else if (family === "ollama") registerApiKeySlot(pi, id, "ollama");
+				else if (family === "openai-codex") {
+					const cached = codexModelCatalogByProvider.get(id)?.models;
+					registerCodexSlot(
+						pi,
+						id,
+						config.autoDiscoverModels && cached?.length
+							? (cached as Array<Record<string, unknown>>)
+							: undefined,
+					);
+				} else if (family === "ollama") registerApiKeySlot(pi, id, "ollama");
 				else if (family === "qwen") registerApiKeySlot(pi, id, "qwen");
 				registeredSlots.add(id);
 			}
@@ -5154,9 +5167,14 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		}
 
 		if (command === "reload") {
+			const previousAutoDiscoverModels = config.autoDiscoverModels;
 			config = loadConfig();
 			debugLogEnabled = config.debugLog;
 			configuredFallbacks = config.fallbacks.slice();
+			if (config.autoDiscoverModels !== previousAutoDiscoverModels) {
+				registryCodexModelOrder = [];
+				if (!config.autoDiscoverModels) discoveredCodexModelOrder = [];
+			}
 			refreshDiscovery(true, ctx);
 			startUsageStatusTimer(ctx);
 			runBackground("reload account metadata refresh", ctx, async () => {

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -3579,6 +3579,101 @@ test("failover messages are stamped with the running version so a stale (un-rest
 	);
 });
 
+test("persisted Codex catalog is registered before session_start so scoped models can resolve", () => {
+	const provider = "openai-codex-account-2";
+	const model = {
+		id: "gpt-5.6-sol",
+		name: "GPT-5.6 Sol",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+		contextWindow: 272_000,
+		maxTokens: 128_000,
+	};
+	const t = setup({
+		config: { autoDiscoverModels: true },
+		seedState: {
+			stateVersion: 5,
+			codexModelCatalogByProvider: {
+				[provider]: { fetchedAt: Date.now(), models: [model] },
+			},
+		},
+	});
+
+	assert.equal(
+		t.ctx.modelRegistry.find(provider, model.id)?.name,
+		model.name,
+		"the cached alias model must exist during extension initialization, before Pi resolves enabledModels",
+	);
+});
+
+test("an empty persisted Codex catalog keeps the static fallback through session_start", async () => {
+	const provider = "openai-codex-account-2";
+	const t = setup({
+		config: { autoDiscoverModels: true },
+		seedState: {
+			stateVersion: 5,
+			codexModelCatalogByProvider: {
+				[provider]: { fetchedAt: Date.now(), models: [] },
+			},
+		},
+	});
+
+	await t.fire("session_start");
+	assert.equal(t.ctx.modelRegistry.find(provider, "gpt-5.5")?.name, "GPT-5.5");
+	await t.fire("session_shutdown");
+});
+
+test("disabled Codex discovery ignores persisted catalogs and keeps host models on aliases", async () => {
+	const provider = "openai-codex-account-2";
+	const t = setup({
+		config: { autoDiscoverModels: false },
+		hostCodexModels: ["gpt-5.7-sol"],
+		seedState: {
+			stateVersion: 5,
+			codexModelCatalogByProvider: {
+				[provider]: {
+					fetchedAt: Date.now(),
+					models: [{ id: "gpt-5.6-sol", name: "Cached 5.6 Sol" }],
+				},
+			},
+		},
+	});
+
+	await t.fire("session_start");
+	assert.equal(t.ctx.modelRegistry.find(provider, "gpt-5.7-sol")?.id, "gpt-5.7-sol");
+	assert.equal(t.ctx.modelRegistry.find(provider, "gpt-5.6-sol"), undefined);
+	await t.fire("session_shutdown");
+});
+
+test("reload disabling Codex discovery replaces cached alias models with host models", async () => {
+	const provider = "openai-codex-account-2";
+	const t = setup({
+		current: { provider: "anthropic", id: "claude-opus-4-8" },
+		config: { autoDiscoverModels: true },
+		hostCodexModels: ["gpt-5.7-sol"],
+		seedState: {
+			stateVersion: 5,
+			codexModelCatalogByProvider: {
+				[provider]: {
+					fetchedAt: Date.now(),
+					models: [{ id: "gpt-5.6-sol", name: "Cached 5.6 Sol" }],
+				},
+			},
+		},
+	});
+	await t.fire("session_start");
+	assert.equal(t.ctx.modelRegistry.find(provider, "gpt-5.6-sol")?.name, "Cached 5.6 Sol");
+
+	writeFileSync(CONFIG, JSON.stringify({ autoDiscoverModels: false }));
+	await t.command("reload");
+	assert.equal(t.ctx.modelRegistry.find(provider, "gpt-5.7-sol")?.id, "gpt-5.7-sol");
+	assert.equal(t.ctx.modelRegistry.find(provider, "gpt-5.6-sol"), undefined);
+	await finishError(t, "anthropic", "claude-opus-4-8", "429 rate limit");
+	assert.equal(t.rec.setModels.at(-1), provider + "/gpt-5.7-sol");
+	await t.fire("session_shutdown");
+});
+
 test(
 	"live OpenAI catalog adds an unseen flagship to account aliases and failover selects it at high",
 	{ concurrency: false },


### PR DESCRIPTION
## What does this PR do?

Seeds numbered Codex aliases from their persisted, credential-free model catalogs during synchronous extension initialization. This makes saved models such as `openai-codex-account-2/gpt-5.6-sol` available before Pi resolves `enabledModels` at startup.

It also:

- falls back to static or host models when a cached catalog is missing or empty;
- ignores persisted discovery catalogs when `autoDiscoverModels` is disabled;
- clears stale discovered ordering when discovery is disabled through `/multi-account reload`;
- adds regression coverage for startup ordering and these fallback paths.

Fixes #7

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (behavior or config change)
- [ ] Docs / chore

## Validation

- [x] `npm run check`
- [x] `npm test` — 138 tests passed
- [x] `npm run pack:check`
- [x] `git diff --check`
- [x] Final reviewer loop returned clean

## Checklist

- [x] `npm run check` passes (TypeScript type-check)
- [x] `npm pack --dry-run` succeeds
- [x] No secrets, tokens, or `auth.json` contents are included
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] I kept the change scoped to a single concern
