### PR TITLE
feat: support max thinking on models that advertise it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-08-16
+
+### Added
+
+- **`max` thinking is available on models that advertise it.** Pi understands `max` — it is in `ThinkingLevel` and `--thinking max` works — but the extension's known-levels list stopped at `xhigh`, so the strongest level of a model offering it was filtered out. GPT-5.6 Sol/Terra/Luna all advertise `max` in the live Codex catalog. Reported by @devtm1123 in #15.
+- **`reasoningLevel: "max"` is accepted in config.** Adding `max` to the catalog alone was not enough: the config parser enumerated the accepted levels and stopped at `xhigh`, so an explicit `max` fell through to `"auto"` — never forced, with nothing said about why. `max` also joins the weakest→strongest ordering, so guarantee #22 (a weaker fallback model's clamp is restored, never adopted) covers it like every other level.
+
+### Notes
+
+- The known-levels list is a **filter, not a grant**: a model's own advertised efforts are intersected with it, so a level named there only ever reaches a model that asked for it. Provider gradations differ wildly and do not nest — Claude Opus 4.6 advertises `max` alone, glm-5.2 has `max` but no `xhigh`, GPT-5.6 has `max`/`xhigh`/`minimal` but no `medium` — which is why the per-model intersection, not the list, decides what any given model gets. Locked by test.
+- The fallback definition for an **unknown** Codex model is deliberately left at `xhigh`. That path is a guess about a model we have no catalog for, and guessing `max` would hand a level to a model that never claimed it.
+
+### Tests
+
+- Guarantee #27: a model that advertises `max` gets it, one that does not is left untouched (including not acquiring a `medium` it never claimed), `reasoningLevel: "max"` is honoured, and `max` is restored after a switch through a weaker model. Verified red→green.
+
 ## [1.16.0] - 2026-08-16
 
 ### Changed

--- a/GUARANTEES.md
+++ b/GUARANTEES.md
@@ -40,6 +40,8 @@ test, not a one-off patch.
 
 | 26 | **A provider's forecast never parks an account.** Reset timestamps and used-percentages are predictions — providers refresh quota windows early and unannounced, and resize the windows themselves — so no cooldown, reset time or usage reading keeps an account from being tried again for longer than `maxRecheckIntervalMs` (default 10 min). Forecasts still order the queue: an account nothing predicts as spent is tried first, and among equals the one that refused longest ago wins. | `a month-long quota forecast cannot park an account past the recheck ceiling` · `once the recheck ceiling elapses, an untried account still outranks one that refused` · `a spent account known ONLY from a STALE usage snapshot ... is still benched` · `a genuinely maxed monthly Codex account is benched for its REAL reset ...` |
 
+| 27 | **Every thinking level a model advertises is available — and none that it doesn't.** `max` is offered on models that advertise it (GPT-5.6 Sol/Terra/Luna do) and accepted as an explicit `reasoningLevel`, restored after a switch like any other level. The known-levels list is a filter, never a grant: provider gradations differ wildly and do not nest, so what a model gets comes from its own advertised efforts. | `a model that advertises max gets max — and one that does not, does not` · `reasoningLevel: max is honoured instead of being silently dropped to auto` · `max survives a switch through a weaker model, exactly like every other level` |
+
 ## How to keep this honest
 
 - **Every bug fix adds a row here and a test.** A fix without a locking test is not done.

--- a/index.ts
+++ b/index.ts
@@ -381,7 +381,14 @@ type ProviderFamily =
 	| "qwen"
 	| "ollama"
 	| "cursor";
-type ReasoningLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+type ReasoningLevel =
+	| "off"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
 // Reasoning levels ordered weakest → strongest. Used to tell a host clamp (a drop forced by a
 // weaker fallback model) apart from a deliberate change by the user.
 const REASONING_LEVELS: ReasoningLevel[] = [
@@ -391,6 +398,7 @@ const REASONING_LEVELS: ReasoningLevel[] = [
 	"medium",
 	"high",
 	"xhigh",
+	"max",
 ];
 // "auto" = follow the session's own level (per-agent `--thinking`, `/thinking`) instead of
 // forcing a global one. Any explicit level still forces that level on every turn.
@@ -625,7 +633,7 @@ const ANTI_PINGPONG_MS = 60 * 1000; // don't switch straight back to the account
 // Bumped on every release. Printed at startup and in `/multi-account status` so you can verify
 // which version Pi actually loaded (a running Pi keeps the version it started with — /login and
 // /reload do NOT reload extension code; only a full restart does).
-const VERSION = "1.16.0";
+const VERSION = "1.17.0";
 const TRANSIENT_PENDING_PREFIX = "temporary provider failure:";
 // Pending reason for a turn that was NOT a model/account failure — the prior turn simply had
 // not gone idle in time, so we re-arm to resume the SAME model. This must never be treated as
@@ -1262,7 +1270,8 @@ function normalizeConfig(raw: ProviderFailoverConfig): RuntimeConfig {
 			raw.reasoningLevel === "low" ||
 			raw.reasoningLevel === "medium" ||
 			raw.reasoningLevel === "high" ||
-			raw.reasoningLevel === "xhigh"
+			raw.reasoningLevel === "xhigh" ||
+			raw.reasoningLevel === "max"
 				? raw.reasoningLevel
 				: "auto",
 		preferredModels:

--- a/model-catalog.ts
+++ b/model-catalog.ts
@@ -25,7 +25,20 @@ export type CodexCatalogSnapshot = {
 const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
-const KNOWN_PI_THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh"];
+// Levels Pi itself understands, weakest → strongest. This is a FILTER, not a grant: a model's
+// own advertised efforts are intersected with this list (see thinkingLevelMap), so a level named
+// here only ever reaches a model that asked for it. Provider gradations differ wildly and do not
+// nest — Claude Opus 4.6 advertises `max` alone, glm-5.2 has `max` but no `xhigh`, gpt-5.6 has
+// `max`/`xhigh`/`minimal` but no `medium` — which is exactly why the per-model intersection, not
+// this list, decides what a given model gets.
+const KNOWN_PI_THINKING_LEVELS = [
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+];
 
 function record(value: unknown): Record<string, any> {
 	return value && typeof value === "object" ? (value as Record<string, any>) : {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-multi-account",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Automatic multi-account failover & rotation for Pi Agent across Anthropic (Claude), OpenAI/ChatGPT Codex, Qwen/Alibaba, and Ollama. Auto-discovers authenticated accounts, grows the rotation on login, and drops accounts on logout, expiry, or quota/rate-limit errors",
   "type": "module",
   "license": "MIT",

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -188,7 +188,15 @@ function setup(opts: {
 	// Pi's real thinking-level semantics: a single mutable session level, clamped to what the
 	// CURRENT model supports, and re-clamped on every model switch (see AgentSession.setModel).
 	// That re-clamp is exactly how the level used to drift downward across failovers.
-	const THINKING_ORDER = ["off", "minimal", "low", "medium", "high", "xhigh"];
+	const THINKING_ORDER = [
+		"off",
+		"minimal",
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+		"max",
+	];
 	let sessionThinkingLevel = opts.thinkingLevel ?? "high";
 	const clampThinking = (level: string) => {
 		const cap = opts.thinkingCaps?.[ctx.model?.provider ?? ""];
@@ -4243,5 +4251,57 @@ test("once the recheck ceiling elapses, an untried account still outranks one th
 	assert.ok(
 		landed[0].startsWith("openai-codex-account-6/"),
 		`the never-tried account must win over the one that refused moments ago (went to ${landed[0]})`,
+	);
+});
+
+test("reasoningLevel: max is honoured instead of being silently dropped to auto", async () => {
+	// Issue #15, second half: adding `max` to the catalog is not enough. The config parser
+	// enumerated the accepted levels and stopped at `xhigh`, so `reasoningLevel: "max"` fell
+	// through to "auto" — the level was never forced, and nothing said why.
+	const t = setup({
+		accounts: THINKING_ACCOUNTS,
+		current: { provider: "anthropic", id: "claude-opus-4-8" },
+		thinkingLevel: "low",
+		config: { reasoningLevel: "max" }, // opt-in override, same as any other explicit level
+	});
+
+	await t.fire("session_start");
+	await t.fire("agent_start");
+
+	assert.equal(
+		t.thinkingLevel(),
+		"max",
+		"an explicitly configured max must be applied, not discarded as unknown",
+	);
+});
+
+test("max survives a switch through a weaker model, exactly like every other level", async () => {
+	// Guarantee #22 ("your thinking level is yours") must hold for the newly-accepted level too:
+	// a weaker fallback model's clamp is restored, never adopted as the new intent.
+	const t = setup({
+		accounts: THINKING_ACCOUNTS,
+		current: { provider: "anthropic", id: "claude-opus-4-8" },
+		thinkingLevel: "max",
+		// The codex account tops out at high — Pi clamps max down to high there.
+		thinkingCaps: { "openai-codex-account-2": "high" },
+	});
+
+	await t.fire("session_start");
+	await t.fire("agent_start");
+	assert.equal(t.thinkingLevel(), "max");
+
+	await t.command("next"); // → codex, where max is clamped to high
+	assert.equal(t.thinkingLevel(), "high", "the host clamp is expected here");
+
+	await t.fire("agent_start");
+	await t.command("next"); // → back to a model that supports max
+	assert.equal(
+		t.thinkingLevel(),
+		"max",
+		`max must return once a capable model is back: ${JSON.stringify(t.rec.thinkingLevels)}`,
+	);
+	assert.ok(
+		!t.rec.thinkingLevels.includes("high"),
+		`the extension must never ASK for the clamped level: ${JSON.stringify(t.rec.thinkingLevels)}`,
 	);
 });

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -120,3 +120,58 @@ test("unknown future Codex generations rank without an extension release", () =>
 		["gpt-5.7-sol", "gpt-5.7-luna", "gpt-5.7-mini", "gpt-5.6-sol"],
 	);
 });
+
+test("a model that advertises max gets max — and one that does not, does not", () => {
+	// Issue #15: Pi understands `max` (ThinkingLevel includes it and `--thinking max` works), but
+	// the extension's known-levels list stopped at `xhigh`, so the strongest level of a model that
+	// offers it was silently filtered out.
+	//
+	// The list is a FILTER, never a grant. Provider gradations differ wildly and do not nest —
+	// Claude Opus 4.6 advertises `max` alone, glm-5.2 has `max` but no `xhigh`, gpt-5.6 has
+	// `max`/`xhigh`/`minimal` but no `medium` — so what a given model gets must come from that
+	// model's own advertised efforts, never from the list.
+	const models = parseCodexModelCatalog({
+		models: [
+			{
+				slug: "advertises-max",
+				display_name: "Advertises Max",
+				visibility: "list",
+				priority: 30,
+				supported_reasoning_levels: [
+					{ effort: "minimal" },
+					{ effort: "xhigh" },
+					{ effort: "max" },
+				],
+			},
+			{
+				slug: "no-max",
+				display_name: "No Max",
+				visibility: "list",
+				priority: 20,
+				supported_reasoning_levels: [
+					{ effort: "medium" },
+					{ effort: "high" },
+					{ effort: "xhigh" },
+				],
+			},
+		],
+	});
+	const withMax = models.find((model) => model.id === "advertises-max");
+	const withoutMax = models.find((model) => model.id === "no-max");
+
+	assert.equal(
+		withMax?.thinkingLevelMap?.max,
+		"max",
+		"a model that advertises max must be offered max",
+	);
+	assert.equal(
+		withoutMax?.thinkingLevelMap?.max,
+		undefined,
+		"a model that never advertised max must NOT be given it — the list filters, it does not grant",
+	);
+	// The gradations that model actually claimed are untouched.
+	assert.equal(withoutMax?.thinkingLevelMap?.xhigh, "xhigh");
+	assert.equal(withoutMax?.thinkingLevelMap?.high, "high");
+	// And a model that never claimed `medium` does not acquire it either.
+	assert.equal(withMax?.thinkingLevelMap?.medium, undefined);
+});


### PR DESCRIPTION
Closes #15.

## Confirmed

Pi understands `max` — it is in `ThinkingLevel` and `--thinking max` works on a real model — but `KNOWN_PI_THINKING_LEVELS` stopped at `xhigh`, so the strongest level of a model offering it was filtered out. **GPT-5.6 Sol/Terra/Luna all advertise `max`** in the live Codex catalog, so this is live on current models, not hypothetical.

## Why the issue's one-line fix would have shipped a half-feature

`max` was missing from three more places:

- the `ReasoningLevel` **type**;
- the weakest→strongest **ordering**;
- the **config parser**, which enumerated accepted levels and stopped at `xhigh` — so `reasoningLevel: "max"` fell through to `"auto"`. The level was silently never forced, and nothing said why.

The ordering matters more than it looks: without `max` in `REASONING_LEVELS`, guarantee #22 cannot tell a host clamp apart from a deliberate change, so a weaker fallback model's clamp would be **adopted** instead of restored — the exact ratchet-down that guarantee exists to prevent.

## Gradations differ per provider, and the design already handles it

The known-levels list is a **filter, not a grant**: a model's own advertised efforts are intersected with it, so a level named there only ever reaches a model that asked for it.

That matters because provider gradations do not nest at all:

| Model | Advertises |
|---|---|
| Claude Opus 4.6 | `max` only |
| glm-5.2 (ollama) | `max`, but **no** `xhigh` |
| GPT-5.6 | `max`, `xhigh`, `minimal` — but **no** `medium` |
| GPT-5.2 | `xhigh` only |

This is now locked by test rather than left to reasoning: a model that advertises `max` gets it, one that does not is untouched, and neither acquires a `medium` it never claimed.

## Deliberately unchanged

The fallback definition for an **unknown** Codex model still stops at `xhigh`. That path is a guess about a model we have no catalog for, and guessing `max` would hand a level to a model that never claimed it. Current and future generations come from the live catalog (guarantee #19), where `max` is present.

## Tests

Guarantee #27. Verified red→green — reverting the levels list fails the catalog assertion, reverting the parser fails the config assertion, and reverting the ordering fails the restore-after-switch assertion.

`npm run release:check`: type-check clean, **155/155 pass**, package check pass.

Thanks @devtm1123 for the report and for testing it locally on GPT-5.6 Luna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)