### PR TITLE
fix: preserve configured max Codex thinking level

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -356,6 +356,7 @@ import {
 	CodexCatalogFetchError,
 	compareCodexModelStrength,
 	fetchCodexModelCatalog,
+	preserveHostMaxReasoningLevel,
 	rankAnthropicModelIds,
 	type CodexCatalogModel,
 	type CodexCatalogSnapshot,
@@ -2576,7 +2577,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		} catch {
 			return [];
 		}
-		return models
+		const mapped = models
 			.filter(
 				(model) =>
 					typeof model?.id === "string" &&
@@ -2598,6 +2599,14 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 					typeof model.contextWindow === "number" ? model.contextWindow : 272_000,
 				maxTokens: typeof model.maxTokens === "number" ? model.maxTokens : 128_000,
 			})) as CodexCatalogModel[];
+		// The host registry may have been replaced by a previous live-catalog refresh.
+		// Read Pi's canonical Codex metadata too, so a later refresh can still recover
+		// levels such as Luna's `max` instead of permanently inheriting xhigh.
+		const canonical = mapped.map((model) => ({
+			id: model.id,
+			thinkingLevelMap: piAiGetModel(CODEX_BASE, model.id)?.thinkingLevelMap,
+		}));
+		return preserveHostMaxReasoningLevel(mapped, canonical);
 	}
 
 	function mergeCodexModels(...groups: CodexCatalogModel[][]): CodexCatalogModel[] {
@@ -2724,7 +2733,10 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 					return;
 				}
 				try {
-					const models = await fetchFreshCodexCatalog(ctx, provider);
+					const models = preserveHostMaxReasoningLevel(
+						await fetchFreshCodexCatalog(ctx, provider),
+						registryFallback,
+					);
 					codexModelCatalogByProvider.set(provider, {
 						fetchedAt: Date.now(),
 						models,
@@ -2752,7 +2764,10 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		discoveredCodexModelOrder = allKnown.map((model) => model.id);
 
 		for (const provider of providers) {
-			const models = codexModelCatalogByProvider.get(provider)?.models ?? registryFallback;
+			const models = preserveHostMaxReasoningLevel(
+				codexModelCatalogByProvider.get(provider)?.models ?? registryFallback,
+				registryFallback,
+			);
 			registerCodexCatalog(pi, provider, models as Array<Record<string, unknown>>);
 		}
 		// Also keep unauthenticated spare login slots current so a newly logged-in account can select

--- a/index.ts
+++ b/index.ts
@@ -2322,7 +2322,11 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	let desiredThinkingLevel: any;
 
 	function captureDesiredThinking() {
-		desiredThinkingLevel = config.reasoningLevel;
+		// Capture the session's ACTUAL thinking level (the per-agent configured value,
+		// e.g. Mimir=low, Brokkr=high) rather than the global config.reasoningLevel.
+		// Using the global default here clobbered per-agent thinking on every agent_start.
+		// This still preserves the level across failovers via restoreDesiredThinking.
+		desiredThinkingLevel = (pi as any).getThinkingLevel?.() ?? config.reasoningLevel;
 		try {
 			(pi as any).setThinkingLevel?.(desiredThinkingLevel);
 		} catch {

--- a/model-catalog.ts
+++ b/model-catalog.ts
@@ -60,6 +60,36 @@ function thinkingLevelMap(efforts: string[]): Record<string, string | null> | un
 	return Object.keys(result).length > 0 ? result : undefined;
 }
 
+/**
+ * Preserve a host-declared `max` level when the account catalog omits it.
+ * Pi's built-in Codex metadata knows about max for Luna, while the live
+ * account endpoint currently reports only through xhigh. The live catalog
+ * still wins for every explicitly reported level.
+ */
+export function preserveHostMaxReasoningLevel(
+	models: CodexCatalogModel[],
+	hostModels: Array<Pick<CodexCatalogModel, "id" | "thinkingLevelMap">>,
+): CodexCatalogModel[] {
+	const hostMax = new Set(
+		hostModels
+			.filter((model) => model.thinkingLevelMap?.max === "max")
+			.map((model) => model.id),
+	);
+	return models.map((model) => {
+		if (
+			!model.reasoning ||
+			!hostMax.has(model.id) ||
+			Object.hasOwn(model.thinkingLevelMap ?? {}, "max")
+		) {
+			return model;
+		}
+		return {
+			...model,
+			thinkingLevelMap: { ...model.thinkingLevelMap, max: "max" },
+		};
+	});
+}
+
 function versionParts(id: string): number[] {
 	const match = id.match(/(?:^|[-_])(?:gpt[-_]?)?(\d+)(?:\.(\d+))?(?:\.(\d+))?/i);
 	return match ? [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)] : [0, 0, 0];

--- a/model-catalog.ts
+++ b/model-catalog.ts
@@ -25,7 +25,7 @@ export type CodexCatalogSnapshot = {
 const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
-const KNOWN_PI_THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh"];
+const KNOWN_PI_THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"];
 
 function record(value: unknown): Record<string, any> {
 	return value && typeof value === "object" ? (value as Record<string, any>) : {};

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -66,7 +66,7 @@ test("live Codex catalog follows server priority: Sol beats Terra and Luna", () 
 				display_name: "5.6 Luna",
 				visibility: "list",
 				priority: 30,
-				supported_reasoning_levels: [{ effort: "high" }, { effort: "xhigh" }],
+				supported_reasoning_levels: [{ effort: "high" }, { effort: "xhigh" }, { effort: "max" }],
 				context_window: 272_000,
 			},
 			{
@@ -104,6 +104,7 @@ test("live Codex catalog follows server priority: Sol beats Terra and Luna", () 
 	);
 	assert.equal(models[0].thinkingLevelMap?.xhigh, "xhigh");
 	assert.equal(models[0].thinkingLevelMap?.minimal, "low");
+	assert.equal(models[2].thinkingLevelMap?.max, "max");
 	assert.deepEqual(models[0].input, ["text", "image"]);
 });
 

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
 	compareCodexModelStrength,
 	parseCodexModelCatalog,
+	preserveHostMaxReasoningLevel,
 	rankAnthropicModelIds,
 } from "../model-catalog.ts";
 
@@ -106,6 +107,44 @@ test("live Codex catalog follows server priority: Sol beats Terra and Luna", () 
 	assert.equal(models[0].thinkingLevelMap?.minimal, "low");
 	assert.equal(models[2].thinkingLevelMap?.max, "max");
 	assert.deepEqual(models[0].input, ["text", "image"]);
+});
+
+test("host Codex metadata preserves max when the live catalog omits it", () => {
+	const live = parseCodexModelCatalog({
+		models: [
+			{
+				slug: "gpt-5.6-luna",
+				visibility: "list",
+				supported_reasoning_levels: [{ effort: "high" }, { effort: "xhigh" }],
+			},
+		],
+	});
+	const preserved = preserveHostMaxReasoningLevel(live, [
+		{
+			id: "gpt-5.6-luna",
+			thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+		},
+	]);
+	assert.equal(preserved[0].thinkingLevelMap?.max, "max");
+});
+
+test("explicitly reported live max metadata wins", () => {
+	const models = preserveHostMaxReasoningLevel(
+		[
+			{
+				id: "gpt-5.6-luna",
+				name: "Luna",
+				reasoning: true,
+				thinkingLevelMap: { max: null },
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1,
+				maxTokens: 1,
+			},
+		],
+		[{ id: "gpt-5.6-luna", thinkingLevelMap: { max: "max" } }],
+	);
+	assert.equal(models[0].thinkingLevelMap?.max, null);
 });
 
 test("unknown future Codex generations rank without an extension release", () => {


### PR DESCRIPTION
When Pi launches a subagent with `--thinking max`, pi-multi-account refreshes the Codex provider from the account catalog. The live catalog can omit Luna's `max` effort, so Pi re-registers the model without `max` and clamps the child to `xhigh` while the parent widget still reports the requested `max`.

This keeps host-declared `max` capability when the live catalog omits it, while respecting explicit live metadata. It also recovers the canonical host metadata after repeated provider refreshes.

Tests: `npm test` (128 passing).