### PR TITLE
fix: surface Ollama Cloud quota windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ollama Cloud now shows its real session and weekly quota instead of claiming that no API exists.** The extension still reads plan and suspension metadata from `/api/me`, then best-effort fetches the live fractional windows from `GET /api/usage`. Because that endpoint and its fixed reset epochs are not yet a stable documented contract, any failure falls back to the plan-only status and inferred reset times remain forecasts subject to the normal recheck ceiling; they never turn a stale estimate into a permanent routing veto.
+
 - **Different Codex users in one Team/Business workspace can occupy separate rotation slots.** Pi stores `chatgpt_account_id`, which identifies the selected workspace rather than the user membership inside it. Deduplicating on that value rejected the second login as the same “real account” and also shared cooldowns between distinct users. Codex identity now prefers the JWT's stable `chatgpt_account_user_id` claim; tokens without it use the documented `chatgpt_user_id` plus workspace id before falling back to the legacy stored `accountId`. Re-login detection uses the same identity, so a refreshed token keeps its cooldown while replacing a slot with another user in the same workspace clears the previous user's state.
 
 - **The Anthropic OAuth billing header now identifies Claude Code `2.1.259`.** This replaces the stale `2.1.241` client version reported in #29.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When the account you are using hits a quota or rate limit, `pi-multi-account` tr
 - **Session-bound overnight resume**: if every account is cooling down, the live Pi session waits for the earliest recovery and continues automatically. A new user message, `/multi-account stop`, session exit, or Esc during a running turn cancels the chain.
 - **Deduplicates provably identical accounts** so duplicate Codex workspace memberships and identical credentials do not consume multiple rotation slots or get separate cooldowns. Different users in one Team/Business workspace remain distinct. New provable duplicate logins are rejected before the redundant slot is saved.
 - **Keeps YOUR reasoning level across switches.** Whatever the session runs at — your Pi default, `/thinking`, or a per-agent `--thinking low` — is preserved and restored after every account/model switch, so it never drifts downward when a weaker fallback model clamps it. The extension does not override your level (set `reasoningLevel` if you *want* a forced one), and extreme levels such as `xhigh` / Max / Ultra are never forced.
-- **Shows live limits for the active account** in Pi's footer: remaining 5-hour and 7-day allowance plus reset countdowns for Codex and Anthropic OAuth accounts.
+- **Shows live limits for the active account** in Pi's footer: remaining 5-hour/session and weekly allowance plus reset countdowns for Codex, Anthropic, and Ollama Cloud accounts.
 
 ## Install
 
@@ -92,7 +92,7 @@ All three names are aliases for the same command: `/multi-account`, `/provider-f
 | Subcommand | Description |
 |---|---|
 | `status` (default) | Show enabled state, current model, rotation, login slots, cooldowns, invalidations, pending resume. |
-| `limits [refresh]` | Show active-account 5h/7d limits; `refresh` bypasses the cache. Aliases: `usage`, `quota`. |
+| `limits [refresh]` | Show active-account session/weekly limits; `refresh` bypasses the cache. Aliases: `usage`, `quota`. |
 | `rediscover` | Force a re-scan of `auth.json`, rebuild the rotation, and refresh Codex model catalogs now. |
 | `add [anthropic\|codex\|kimi\|cursor\|ollama\|qwen]` | Print the next free account slot to select from the interactive `/login` picker. Subscription families (Anthropic, Codex, Kimi, Cursor) are logged in through `/login`; API-key families are filled in `auth.json`. |
 | `remove [anthropic\|codex\|kimi\|cursor\|ollama\|qwen\|<provider-id>]` | Remove an account from `auth.json` and rotation. Family name drops the highest numbered alias slot; a full provider id removes that exact slot. Aliases: `rm`, `delete`. |
@@ -172,7 +172,7 @@ A failover is only useful if the agent actually keeps working afterward. These g
 
 ## Privacy & security
 
-`pi-multi-account` **reads** `auth.json` but never writes credentials itself and never stores credentials in its state. Account/token values are reduced to a short irreversible SHA-256 fingerprint for re-login detection and deduplication. OAuth access tokens are sent only to their own provider: the usage endpoint (`chatgpt.com/backend-api/wham/usage` or `api.anthropic.com/api/oauth/usage`) and, for Codex, OpenAI's authenticated `chatgpt.com/backend-api/codex/models` catalog. Cached state contains percentages, reset times, plan/credit metadata, model metadata, and the fingerprint, never the token. Config, state, and the debug log are written with `0600` permissions. The debug log records only provider/model ids, decisions, and truncated reasons — token-shaped material is redacted defensively — so it is safe to share when reporting an issue. Disable it with `"debugLog": false` or `/multi-account log off`.
+`pi-multi-account` **reads** `auth.json` but never writes credentials itself and never stores credentials in its state. Account/token values are reduced to a short irreversible SHA-256 fingerprint for re-login detection and deduplication. Credentials are sent only to their own provider usage/account endpoints (`chatgpt.com/backend-api/wham/usage`, `api.anthropic.com/api/oauth/usage`, or Ollama Cloud's `/api/me` and `/api/usage`) and, for Codex, OpenAI's authenticated `chatgpt.com/backend-api/codex/models` catalog. Cached state contains percentages, reset times, plan/credit metadata, model metadata, and the fingerprint, never the token. Config, state, and the debug log are written with `0600` permissions. The debug log records only provider/model ids, decisions, and truncated reasons — token-shaped material is redacted defensively — so it is safe to share when reporting an issue. Disable it with `"debugLog": false` or `/multi-account log off`.
 
 ## License
 

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -7,6 +7,7 @@ import {
 	parseCodexUsageBody,
 	parseCodexUsageHeaders,
 	parseOllamaMeBody,
+	parseOllamaUsageBody,
 } from "../usage.ts";
 
 const NOW = Date.UTC(2026, 5, 13, 12, 0, 0);
@@ -44,8 +45,8 @@ test("parses Codex 5h and weekly usage response", () => {
 });
 
 test("Ollama /api/me surfaces plan tier, renewal date, and suspended status", () => {
-	// Ollama exposes no token counters, but /api/me carries the plan, billing-period end, and a
-	// suspended flag — fold them into the plan line so the footer shows something real.
+	// /api/me carries account metadata while /api/usage carries the quota windows. Keep this useful
+	// fallback when the best-effort quota request is unavailable.
 	const active = parseOllamaMeBody(
 		"ollama",
 		{
@@ -59,7 +60,7 @@ test("Ollama /api/me surfaces plan tier, renewal date, and suspended status", ()
 	assert.equal(active.plan, "pro · renews 2026-07-16");
 	assert.equal(
 		formatUsageCompact(active, NOW),
-		"Ollama | pro · renews 2026-07-16 · no session/weekly API",
+		"Ollama | pro · renews 2026-07-16 · quota unavailable",
 	);
 
 	const suspended = parseOllamaMeBody(
@@ -72,6 +73,87 @@ test("Ollama /api/me surfaces plan tier, renewal date, and suspended status", ()
 		suspended.plan?.includes("SUSPENDED"),
 		`suspended plan should flag it, got ${suspended.plan}`,
 	);
+});
+
+test("parses Ollama session and weekly quota fractions with forecast reset boundaries", () => {
+	const snapshot = parseOllamaUsageBody(
+		"ollama-account-2",
+		{
+			limits: {
+				session: { usage: 0.046, models: [{ name: "glm-5", request_count: 3 }] },
+				weekly: { usage: 0.051, models: [] },
+			},
+		},
+		NOW,
+		"cred",
+	);
+	assert.ok(snapshot);
+	assert.equal(snapshot.primary?.usedPercent, 4.6);
+	assert.equal(snapshot.primary?.windowSeconds, 18_000);
+	// Session epochs are exact 18,000-second multiples from Unix epoch, so their UTC wall-clock
+	// hour moves across days rather than always landing on 00/05/10/15/20.
+	assert.equal(snapshot.primary?.resetAt, Date.UTC(2026, 5, 13, 17, 0, 0));
+	assert.equal(snapshot.secondary?.usedPercent, 5.1);
+	assert.equal(snapshot.secondary?.resetAt, Date.UTC(2026, 5, 15, 0, 0, 0));
+	assert.equal(
+		formatUsageCompact(snapshot, NOW),
+		"Ollama A2 | session 95% left/5h | weekly 95% left/1d12h",
+	);
+});
+
+test("Ollama null or non-fraction quota values do not invent windows", () => {
+	assert.equal(
+		parseOllamaUsageBody("ollama", {
+			limits: { session: { usage: null }, weekly: { usage: 52 } },
+		}),
+		undefined,
+	);
+});
+
+test("Ollama combines /api/me metadata with best-effort /api/usage windows", async () => {
+	const calls: Array<{ url: string; method: string }> = [];
+	const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = String(input);
+		calls.push({ url, method: init?.method ?? "GET" });
+		if (url.endsWith("/api/me")) {
+			return new Response(JSON.stringify({ Plan: "pro" }), { status: 200 });
+		}
+		return new Response(
+			JSON.stringify({ limits: { session: { usage: 0.25 }, weekly: { usage: 0.5 } } }),
+			{ status: 200 },
+		);
+	}) as typeof fetch;
+
+	const snapshot = await fetchUsageSnapshot(
+		"ollama",
+		{ type: "api_key", key: "ollama-secret" },
+		{ fetchImpl, credentialHash: "safe-hash" },
+	);
+	assert.deepEqual(calls, [
+		{ url: "https://ollama.com/api/me", method: "POST" },
+		{ url: "https://ollama.com/api/usage", method: "GET" },
+	]);
+	assert.equal(snapshot.plan, "pro");
+	assert.equal(snapshot.primary?.usedPercent, 25);
+	assert.equal(snapshot.secondary?.usedPercent, 50);
+	assert.equal(snapshot.credentialHash, "safe-hash");
+	assert.ok(!JSON.stringify(snapshot).includes("ollama-secret"));
+});
+
+test("Ollama keeps the plan snapshot when the best-effort usage endpoint fails", async () => {
+	const fetchImpl = (async (input: string | URL | Request) => {
+		return String(input).endsWith("/api/me")
+			? new Response(JSON.stringify({ Plan: "pro" }), { status: 200 })
+			: new Response("unavailable", { status: 503 });
+	}) as typeof fetch;
+	const snapshot = await fetchUsageSnapshot(
+		"ollama",
+		{ type: "api_key", key: "ollama-secret" },
+		{ fetchImpl },
+	);
+	assert.equal(snapshot.plan, "pro");
+	assert.equal(snapshot.primary, undefined);
+	assert.match(formatUsageCompact(snapshot), /quota unavailable/);
 });
 
 test("parses case-insensitive Codex response headers", () => {

--- a/usage.ts
+++ b/usage.ts
@@ -225,9 +225,9 @@ export function parseOllamaMeBody(
 			: typeof source.plan === "string"
 				? source.plan
 				: undefined;
-	// Ollama's /api/me exposes NO session/weekly token counters, but it DOES carry the plan tier,
-	// the billing-period end (when the monthly allowance renews) and a suspended flag — all worth
-	// surfacing. Fold them into the plan string since UsageSnapshot has no dedicated field.
+	// Ollama's /api/me carries the plan tier, billing-period end and suspended flag. Current cloud
+	// quota windows come from /api/usage, but retain support for windows here in case Ollama folds
+	// them into the documented account response later.
 	const nullableTime = (value: unknown): string | undefined => {
 		if (!value || typeof value !== "object") return undefined;
 		const v = value as { Time?: unknown; Valid?: unknown };
@@ -261,6 +261,63 @@ export function parseOllamaMeBody(
 		fetchedAt,
 		credentialHash,
 		plan,
+		primary,
+		secondary,
+	};
+}
+
+const OLLAMA_SESSION_SECONDS = 5 * 60 * 60;
+const OLLAMA_WEEK_SECONDS = 7 * 24 * 60 * 60;
+const OLLAMA_WEEK_ANCHOR_MS = 4 * 24 * 60 * 60_000; // Monday 00:00 UTC after Unix epoch.
+
+function nextBoundary(now: number, windowMs: number, anchorMs = 0): number {
+	return anchorMs + (Math.floor((now - anchorMs) / windowMs) + 1) * windowMs;
+}
+
+function ollamaFractionWindow(
+	value: unknown,
+	fetchedAt: number,
+	windowSeconds: number,
+	anchorMs = 0,
+): UsageWindow | undefined {
+	const rawUsage = record(value).usage;
+	if (rawUsage === null || rawUsage === undefined || rawUsage === "") return undefined;
+	const usage = finiteNumber(rawUsage);
+	// Ollama documents this only through its live response today. Be strict about the observed
+	// fractional shape so a future percentage-valued response cannot silently turn 50% into 100%.
+	if (usage === undefined || usage < 0 || usage > 1) return undefined;
+	return {
+		usedPercent: usage * 100,
+		resetAt: nextBoundary(fetchedAt, windowSeconds * 1000, anchorMs),
+		windowSeconds,
+	};
+}
+
+/** Parse Ollama Cloud's best-effort /api/usage session and weekly quota fractions. */
+export function parseOllamaUsageBody(
+	provider: string,
+	body: unknown,
+	fetchedAt = Date.now(),
+	credentialHash?: string,
+): UsageSnapshot | undefined {
+	const limits = record(record(body).limits);
+	const primary = ollamaFractionWindow(
+		limits.session,
+		fetchedAt,
+		OLLAMA_SESSION_SECONDS,
+	);
+	const secondary = ollamaFractionWindow(
+		limits.weekly,
+		fetchedAt,
+		OLLAMA_WEEK_SECONDS,
+		OLLAMA_WEEK_ANCHOR_MS,
+	);
+	if (!primary && !secondary) return undefined;
+	return {
+		provider,
+		family: "ollama",
+		fetchedAt,
+		credentialHash,
 		primary,
 		secondary,
 	};
@@ -308,12 +365,40 @@ async function fetchOllamaUsageSnapshot(
 			);
 		}
 		const body = await response.json();
-		return parseOllamaMeBody(
+		const account = parseOllamaMeBody(
 			provider,
 			body,
 			Date.now(),
 			options.credentialHash,
 		);
+		// /api/usage is not yet a stable documented contract. Its failure must never erase the
+		// useful /api/me account status or make a healthy Ollama key look invalid.
+		try {
+			const usageResponse = await fetchImpl("https://ollama.com/api/usage", {
+				method: "GET",
+				headers,
+				signal: controller.signal,
+			});
+			if (usageResponse.ok) {
+				const usage = parseOllamaUsageBody(
+					provider,
+					await usageResponse.json(),
+					Date.now(),
+					options.credentialHash,
+				);
+				if (usage) {
+					return {
+						...account,
+						fetchedAt: usage.fetchedAt,
+						primary: usage.primary ?? account.primary,
+						secondary: usage.secondary ?? account.secondary,
+					};
+				}
+			}
+		} catch {
+			// Best-effort endpoint: preserve the plan-only account snapshot.
+		}
+		return account;
 	} catch (error) {
 		if (error instanceof UsageFetchError) throw error;
 		if ((error as any)?.name === "AbortError") {
@@ -486,7 +571,7 @@ export function windowLabel(
 	position: "primary" | "secondary",
 ): string {
 	if (family === "cursor") return position === "primary" ? "auth" : "7d";
-	if (family === "ollama") return position === "primary" ? "cloud" : "weekly";
+	if (family === "ollama") return position === "primary" ? "session" : "weekly";
 	const seconds = window.windowSeconds;
 	if (!seconds) return position === "primary" ? "5h" : "7d";
 	if (seconds >= 20 * 86_400) return "30d";
@@ -522,7 +607,7 @@ export function formatUsageCompact(snapshot: UsageSnapshot, now = Date.now()): s
 	}
 	if (!snapshot.primary && !snapshot.secondary && snapshot.plan) {
 		if (snapshot.family === "ollama") {
-			parts.push(`${snapshot.plan} · no session/weekly API`);
+			parts.push(`${snapshot.plan} · quota unavailable`);
 		} else {
 			parts.push(snapshot.plan);
 		}
@@ -543,7 +628,7 @@ export function formatUsageDetails(snapshot: UsageSnapshot, now = Date.now()): s
 	if (!snapshot.primary && !snapshot.secondary && snapshot.plan) {
 		if (snapshot.family === "ollama") {
 			lines.push(
-				`Plan: ${snapshot.plan}. Session/weekly limits are not exposed via Ollama's API yet — check https://ollama.com/settings`,
+				`Plan: ${snapshot.plan}. Session/weekly quota is currently unavailable — check https://ollama.com/settings`,
 			);
 		} else {
 			lines.push(`Status: ${snapshot.plan}`);


### PR DESCRIPTION
Fixes #30.

- best-effort fetches `GET https://ollama.com/api/usage` after the existing `/api/me` account check
- parses observed fractional session and weekly usage values
- forecasts the current fixed-epoch reset boundaries while retaining the extension's normal recheck ceiling
- preserves plan/suspension metadata when the unstable endpoint fails or changes shape
- replaces the stale “no session/weekly API” message with an honest unavailable fallback
- documents the added credential destination

Validation: `npm run release:check` (461/461 tests, package and privacy checks pass).