### PR TITLE
release: 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-09-03
+
 ### Added
 
 - **A `pi-subagents` child now keeps the exact model its parent runner launched.** Native children carry `PI_SUBAGENT_CHILD=1`; inside that boundary this extension remains available for provider/account registration, OAuth request shaping, and catalogs, but becomes passive as a router. It no longer restores the interactive process's remembered model during `session_start`, persists a child model as the user's preference, intercepts provider errors, switches models, queues inputs, routes compaction, or auto-continues. The provider error reaches `pi-subagents` unchanged, so its verified `fallbackModels` chain remains the single routing authority. This fixes children launched as `qoder/qfmodel:high` being changed milliseconds later to the parent process's `qoder/qmodel_38max:medium` or even an unrelated `openai-codex` model, then rejected by `model_verification_failed` after completing the work.

--- a/index.ts
+++ b/index.ts
@@ -1098,7 +1098,7 @@ const ANTI_PINGPONG_MS = 60 * 1000; // don't switch straight back to the account
 // Bumped on every release. Printed at startup and in `/multi-account status` so you can verify
 // which version Pi actually loaded (a running Pi keeps the version it started with — /login and
 // /reload do NOT reload extension code; only a full restart does).
-const VERSION = "1.20.0";
+const VERSION = "1.21.0";
 const MODEL_CATALOG_REQUEST_EVENT = "pi:model-catalog:request:v1";
 const MODEL_CATALOG_SNAPSHOT_EVENT = "pi:model-catalog:snapshot:v1";
 const TRANSIENT_PENDING_PREFIX = "temporary provider failure:";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-multi-account",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-multi-account",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-multi-account",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Automatic multi-account failover & rotation for Pi Agent across Anthropic (Claude), OpenAI/ChatGPT Codex, Kimi For Coding, Cursor, Qwen/Alibaba, and Ollama. Auto-discovers authenticated accounts, grows the rotation on login, and drops accounts on logout, expiry, or quota/rate-limit errors",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Prepares the accumulated post-1.20 changes for npm publication.

- bumps package, lockfile, and runtime-reported version to `1.21.0`
- promotes the current Unreleased changelog to `1.21.0` dated 2026-09-03

Validation: `npm run release:check` (463/463 tests, package and privacy checks pass).

After merge: create `v1.21.0`, validate the trusted-publishing workflow in dry-run mode, publish to npm under `latest`, and create the GitHub release.