### PR TITLE
fix: respect explicit CLI model and thinking selections

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3551,11 +3551,29 @@ export function isSubagentChildProcess(
 	return env[SUBAGENT_CHILD_ENV] === "1";
 }
 
+function parseExplicitCliThinkingLevel(
+	argv: readonly string[] = process.argv,
+): ReasoningLevel | undefined {
+	let level: ReasoningLevel | undefined;
+	for (let i = 2; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--") break;
+		if (arg === "--model" || arg === "--thinking") {
+			if (i + 1 < argv.length) {
+				const value = argv[++i];
+				if (arg === "--thinking" && REASONING_LEVELS.includes(value as ReasoningLevel)) {
+					level = value as ReasoningLevel;
+				}
+			}
+		}
+	}
+	return level;
+}
+
 export function explicitCliSelections(
 	argv: readonly string[] = process.argv,
 ): { model: boolean; thinking: boolean } {
 	let model = false;
-	let thinking = false;
 	for (let i = 2; i < argv.length; i++) {
 		const arg = argv[i];
 		if (arg === "--") break;
@@ -3563,11 +3581,10 @@ export function explicitCliSelections(
 			model = true;
 			i++;
 		} else if (arg === "--thinking" && i + 1 < argv.length) {
-			thinking = true;
 			i++;
 		}
 	}
-	return { model, thinking };
+	return { model, thinking: parseExplicitCliThinkingLevel(argv) !== undefined };
 }
 
 export default function piMultiAccount(pi: ExtensionAPI) {
@@ -3580,8 +3597,12 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	const oauthUnavailable = piAiOauthUnavailableReason();
 	const subagentChild = isSubagentChildProcess();
 	const explicitCli = explicitCliSelections();
+	const explicitCliThinkingAtRegistration = parseExplicitCliThinkingLevel();
 	const hasExplicitCliSelection = explicitCli.model || explicitCli.thinking;
-	let explicitCliSelectionChanged = !hasExplicitCliSelection;
+	// A CLI launch owns both remembered dimensions until a genuine user change takes ownership
+	// of that dimension. Otherwise a model-only launch can persist its thinking clamp (or vice versa).
+	let modelPreferenceChanged = !hasExplicitCliSelection;
+	let thinkingPreferenceChanged = !hasExplicitCliSelection;
 	const sessionInstanceId = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
 	let config = loadConfig();
 	const automaticFailoverEnabled = () => config.enabled && !subagentChild;
@@ -4010,6 +4031,8 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	let lastLeftProvider: string | undefined; // account we just failed away from (anti-ping-pong)
 	let lastLeftAt = 0;
 	let automaticModelTarget: ModelRef | undefined;
+	let lastObservedModelKey: string | undefined;
+	let pendingModelThinkingChange: { model: string; level: ReasoningLevel } | undefined;
 	// Forward-progress watchdog state. A "resume in flight" is a continuation WE dispatched
 	// (pi.continueAgent after a switch) whose new turn must keep showing activity. Any stream
 	// token, tool event, or provider response is "progress" and disarms the stuck timer; total
@@ -4058,9 +4081,9 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	// forcing config.reasoningLevel on every agent_start clobbered per-agent thinking, so an
 	// agent configured `low` was flipped to `high` on its first turn (issue #6).
 	let desiredThinkingLevel: ReasoningLevel | undefined;
-	// What the host clamped our level down to, and on which model. A clamp is the fallback
-	// model's cap, NOT a user decision — it must never become the new intent, otherwise one
-	// failover to a weaker model would ratchet thinking down for the rest of the session.
+	let explicitCliThinkingLevel: ReasoningLevel | undefined = explicitCliThinkingAtRegistration;
+	// What the host applied after we asserted the session's intent, and on which model. A
+	// capability clamp or model default is NOT a user decision, otherwise thinking ratchets.
 	let thinkingClamp: { model: string; level: ReasoningLevel } | undefined;
 
 	const thinkingRank = (level: unknown) =>
@@ -4076,6 +4099,9 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		}
 	}
 
+	if (explicitCli.thinking && !explicitCliThinkingLevel)
+		explicitCliThinkingLevel = readThinkingLevel();
+
 	const thinkingModelKey = (ctx?: any) =>
 		ctx?.model?.provider && ctx?.model?.id
 			? ref(ctx.model.provider, ctx.model.id)
@@ -4088,7 +4114,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			!!thinkingClamp &&
 			thinkingClamp.level === level &&
 			thinkingClamp.model === thinkingModelKey(ctx) &&
-			thinkingRank(level) < thinkingRank(desiredThinkingLevel)
+			level !== desiredThinkingLevel
 		);
 	}
 
@@ -6805,15 +6831,23 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			subagentChild ||
 			!model?.provider ||
 			!model?.id ||
-			(hasExplicitCliSelection && !explicitCliSelectionChanged)
+			(!modelPreferenceChanged && !thinkingPreferenceChanged)
 		)
 			return;
-		const family = classifyProvider(model.provider, config.qwenProvider);
-		if (family) lastModelByFamily[family] = model.id;
+		const rememberedModel = modelPreferenceChanged
+			? { provider: model.provider, id: model.id }
+			: persistedState.lastUserModel;
+		if (!rememberedModel?.provider || !rememberedModel.id) return;
+		if (modelPreferenceChanged) {
+			const family = classifyProvider(model.provider, config.qwenProvider);
+			if (family) lastModelByFamily[family] = model.id;
+		}
 		persist(
 			{
-				lastUserModel: { provider: model.provider, id: model.id },
-				lastUserThinkingLevel: desiredThinkingLevel ?? readThinkingLevel(),
+				lastUserModel: rememberedModel,
+				lastUserThinkingLevel: thinkingPreferenceChanged
+					? desiredThinkingLevel ?? readThinkingLevel()
+					: persistedState.lastUserThinkingLevel,
 				lastModelByFamily: { ...lastModelByFamily },
 			},
 			{ writeUserPreferences: true },
@@ -6835,6 +6869,9 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			logEvent("remembered_model_skipped", { reason: "explicit CLI model" });
 			return false;
 		}
+		const cliThinkingLevel = explicitCli.thinking
+			? (explicitCliThinkingLevel ?? readThinkingLevel())
+			: undefined;
 		const intended = intendedStartupModel();
 		if (!intended) {
 			logEvent("remembered_model_skipped", { reason: "no intended model" });
@@ -6844,7 +6881,8 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			ctx.model?.provider === intended.provider &&
 			ctx.model?.id === intended.id;
 		if (alreadyThere) {
-			if (!explicitCli.thinking) restoreDesiredThinking(ctx);
+			if (explicitCli.thinking) desiredThinkingLevel = cliThinkingLevel ?? desiredThinkingLevel;
+			restoreDesiredThinking(ctx);
 			return true;
 		}
 		if (cursorReady) {
@@ -6868,6 +6906,12 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 				? ref(ctx.model.provider, ctx.model.id)
 				: "none";
 		const to = ref(intended.provider, intended.id);
+		if (explicitCli.thinking) {
+			desiredThinkingLevel = cliThinkingLevel ?? desiredThinkingLevel;
+		} else {
+			const rememberedLevel = persistedState.lastUserThinkingLevel;
+			if (rememberedLevel) desiredThinkingLevel = rememberedLevel as ReasoningLevel;
+		}
 		automaticModelTarget = to;
 		let ok = false;
 		try {
@@ -6883,15 +6927,15 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			source: persistedState.lastUserModel ? "state" : "settings",
 		});
 		if (ok) {
-			// Restore the user's level too — Pi clamped it to the fallback model's caps
-			// while creating the session.
-			if (!explicitCli.thinking) {
+			// Pi resets thinking while changing models. Re-assert either the explicit CLI level
+			// captured before that reset or the ordinary remembered level.
+			if (explicitCli.thinking) {
+				desiredThinkingLevel = cliThinkingLevel ?? desiredThinkingLevel;
+			} else {
 				const rememberedLevel = persistedState.lastUserThinkingLevel;
-				if (rememberedLevel) {
-					desiredThinkingLevel = rememberedLevel as ReasoningLevel;
-				}
-				restoreDesiredThinking(ctx);
+				if (rememberedLevel) desiredThinkingLevel = rememberedLevel as ReasoningLevel;
 			}
+			restoreDesiredThinking(ctx);
 			ctx.ui?.notify?.(
 				`pi-multi-account: restored ${to} after catalog load (Pi had fallen back to ${from})`,
 				"info",
@@ -10227,6 +10271,8 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	}
 
 	safeOn("session_start", async (_event, ctx) => {
+		lastObservedModelKey = thinkingModelKey(ctx);
+		pendingModelThinkingChange = undefined;
 		modelCatalogContext = ctx;
 		if (!subagentChild) preflightHostCapabilities(ctx);
 		// Looked at BEFORE discovery touches anything, so what is judged is the files as Pi
@@ -10591,7 +10637,18 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		if (subagentChild || internalThinkingChanges > 0) return;
 		const level = (event as any).level;
 		if (thinkingRank(level) < 0) return;
-		if (hasExplicitCliSelection) explicitCliSelectionChanged = true;
+		const modelKey = thinkingModelKey(ctx);
+		// Pi applies a model's thinking default/clamp before it emits model_select. The changed
+		// ctx.model identifies that one event; do not turn it into user intent.
+		if (
+			lastObservedModelKey &&
+			modelKey !== "unknown" &&
+			modelKey !== lastObservedModelKey
+		) {
+			pendingModelThinkingChange = { model: modelKey, level: level as ReasoningLevel };
+			return;
+		}
+		thinkingPreferenceChanged = true;
 		desiredThinkingLevel = level as ReasoningLevel;
 		thinkingClamp = undefined;
 		rememberUserModel(ctx?.model);
@@ -10608,13 +10665,19 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			refreshUsage(ctx, model.provider),
 		);
 		const selected = ref(model.provider, model.id);
+		const pendingThinking = pendingModelThinkingChange;
+		pendingModelThinkingChange = undefined;
+		lastObservedModelKey = selected;
+		if (pendingThinking?.model === selected) {
+			thinkingClamp = pendingThinking;
+		}
 		if (automaticModelTarget === selected) {
 			automaticModelTarget = undefined;
 			rememberUserModel(model);
 			return;
 		}
 		if ((event as any).source === "restore") return;
-		explicitCliSelectionChanged = true;
+		modelPreferenceChanged = true;
 		rememberUserModel(model);
 		// A manual model change is user control, not a permanent "never fail over" pin.
 		// Cancel stale pending work; if the selected model then returns a real limit, normal

--- a/index.ts
+++ b/index.ts
@@ -3712,7 +3712,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	}
 
 	/** pi.setModel that first restores the target's models when the filter hid them. */
-	let internalThinkingChanges = 0;
+	let internalModelChanges = 0;
 	async function setModelEnsuringVisible(
 		target: { provider: string; id: string },
 		ctx: any,
@@ -3720,11 +3720,11 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		if (onlyActiveModels) unhideProvider(target.provider);
 		// Pi rewrites settings.json on this path; the next turn checks that it actually did.
 		pendingSettingsCheck = true;
-		internalThinkingChanges++;
+		internalModelChanges++;
 		try {
 			return await pi.setModel(target as any);
 		} finally {
-			internalThinkingChanges--;
+			internalModelChanges--;
 		}
 	}
 
@@ -4085,6 +4085,18 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	// What the host applied after we asserted the session's intent, and on which model. A
 	// capability clamp or model default is NOT a user decision, otherwise thinking ratchets.
 	let thinkingClamp: { model: string; level: ReasoningLevel } | undefined;
+	type InternalThinkingChangeEvidence = {
+		model: string;
+		previousLevel: ReasoningLevel;
+		appliedLevel: ReasoningLevel;
+	};
+	const pendingInternalThinkingChanges: InternalThinkingChangeEvidence[] = [];
+	const MAX_PENDING_INTERNAL_THINKING_CHANGES = 8;
+	let activeInternalThinkingChange:
+		| (Omit<InternalThinkingChangeEvidence, "appliedLevel"> & {
+				appliedLevel?: ReasoningLevel;
+			})
+		| undefined;
 
 	const thinkingRank = (level: unknown) =>
 		REASONING_LEVELS.indexOf(level as ReasoningLevel);
@@ -4106,6 +4118,38 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		ctx?.model?.provider && ctx?.model?.id
 			? ref(ctx.model.provider, ctx.model.id)
 			: "unknown";
+
+	function consumeInternalThinkingChange(
+		event: any,
+		ctx: any,
+		appliedLevel: ReasoningLevel,
+	): boolean {
+		const previousLevel = event?.previousLevel;
+		if (thinkingRank(previousLevel) < 0) return false;
+		const model = thinkingModelKey(ctx);
+		const active = activeInternalThinkingChange;
+		// The first extension handler can run inside setThinkingLevel(), before the applied level
+		// is available to restoreDesiredThinking(). Reading it here completes the same exact key.
+		if (
+			active &&
+			active.model === model &&
+			active.previousLevel === previousLevel &&
+			readThinkingLevel() === appliedLevel
+		) {
+			active.appliedLevel = appliedLevel;
+			activeInternalThinkingChange = undefined;
+			return true;
+		}
+		const pending = pendingInternalThinkingChanges.findIndex(
+			(change) =>
+				change.model === model &&
+				change.previousLevel === previousLevel &&
+				change.appliedLevel === appliedLevel,
+		);
+		if (pending < 0) return false;
+		pendingInternalThinkingChanges.splice(pending, 1);
+		return true;
+	}
 
 	// A level lower than the intent that is exactly what the host produced last time we asserted
 	// the intent on THIS model is a clamp, not the user lowering thinking on purpose.
@@ -4145,17 +4189,33 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 
 	function restoreDesiredThinking(ctx?: any) {
 		if (!desiredThinkingLevel) return;
-		internalThinkingChanges++;
+		const previousLevel = readThinkingLevel();
+		const attempted: typeof activeInternalThinkingChange = previousLevel
+			? { model: thinkingModelKey(ctx), previousLevel }
+			: undefined;
+		if (attempted) activeInternalThinkingChange = attempted;
 		try {
 			(pi as any).setThinkingLevel?.(desiredThinkingLevel);
 		} catch {
 			/* setThinkingLevel clamps to model caps; ignore if unsupported */
 		} finally {
-			internalThinkingChanges--;
+			if (activeInternalThinkingChange === attempted)
+				activeInternalThinkingChange = undefined;
 		}
 		// Record a clamp so the next turn does not mistake the fallback model's cap for intent.
 		const applied = readThinkingLevel();
 		if (!applied) return;
+		if (
+			attempted &&
+			applied !== previousLevel &&
+			attempted.appliedLevel === undefined
+		) {
+			pendingInternalThinkingChanges.push({ ...attempted, appliedLevel: applied });
+			// Keep suppression one-shot and bounded. If the host stops delivering events, drop the
+			// oldest evidence instead of accumulating permanent future suppressions.
+			if (pendingInternalThinkingChanges.length > MAX_PENDING_INTERNAL_THINKING_CHANGES)
+				pendingInternalThinkingChanges.shift();
+		}
 		if (applied !== desiredThinkingLevel) {
 			thinkingClamp = { model: thinkingModelKey(ctx), level: applied };
 			logEvent("thinking_clamped", {
@@ -8015,7 +8075,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 				) {
 					automaticModelTarget = same;
 					if (onlyActiveModels) unhideProvider(sourceModel.provider);
-					internalThinkingChanges++;
+					internalModelChanges++;
 					try {
 						await pi.setModel(
 							ctx.modelRegistry.find(sourceModel.provider, sourceModel.id) ?? {
@@ -8024,7 +8084,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 							},
 						);
 					} finally {
-						internalThinkingChanges--;
+						internalModelChanges--;
 						if (automaticModelTarget === same) automaticModelTarget = undefined;
 					}
 				}
@@ -10634,9 +10694,11 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	});
 
 	safeOn("thinking_level_select", (event, ctx) => {
-		if (subagentChild || internalThinkingChanges > 0) return;
+		if (subagentChild) return;
 		const level = (event as any).level;
 		if (thinkingRank(level) < 0) return;
+		if (consumeInternalThinkingChange(event, ctx, level as ReasoningLevel)) return;
+		if (internalModelChanges > 0) return;
 		const modelKey = thinkingModelKey(ctx);
 		// Pi applies a model's thinking default/clamp before it emits model_select. The changed
 		// ctx.model identifies that one event; do not turn it into user intent.

--- a/index.ts
+++ b/index.ts
@@ -3551,6 +3551,25 @@ export function isSubagentChildProcess(
 	return env[SUBAGENT_CHILD_ENV] === "1";
 }
 
+export function explicitCliSelections(
+	argv: readonly string[] = process.argv,
+): { model: boolean; thinking: boolean } {
+	let model = false;
+	let thinking = false;
+	for (let i = 2; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--") break;
+		if (arg === "--model" && i + 1 < argv.length) {
+			model = true;
+			i++;
+		} else if (arg === "--thinking" && i + 1 < argv.length) {
+			thinking = true;
+			i++;
+		}
+	}
+	return { model, thinking };
+}
+
 export default function piMultiAccount(pi: ExtensionAPI) {
 	// Warm up the OAuth helpers before any provider registration: providers are
 	// registered synchronously below and their `usesCallbackServer`/`getApiKey`
@@ -3560,6 +3579,9 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	// logins are unavailable, and the user is told once at session start.
 	const oauthUnavailable = piAiOauthUnavailableReason();
 	const subagentChild = isSubagentChildProcess();
+	const explicitCli = explicitCliSelections();
+	const hasExplicitCliSelection = explicitCli.model || explicitCli.thinking;
+	let explicitCliSelectionChanged = !hasExplicitCliSelection;
 	const sessionInstanceId = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
 	let config = loadConfig();
 	const automaticFailoverEnabled = () => config.enabled && !subagentChild;
@@ -3669,6 +3691,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	}
 
 	/** pi.setModel that first restores the target's models when the filter hid them. */
+	let internalThinkingChanges = 0;
 	async function setModelEnsuringVisible(
 		target: { provider: string; id: string },
 		ctx: any,
@@ -3676,7 +3699,12 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		if (onlyActiveModels) unhideProvider(target.provider);
 		// Pi rewrites settings.json on this path; the next turn checks that it actually did.
 		pendingSettingsCheck = true;
-		return pi.setModel(target as any);
+		internalThinkingChanges++;
+		try {
+			return await pi.setModel(target as any);
+		} finally {
+			internalThinkingChanges--;
+		}
 	}
 
 	/**
@@ -4091,10 +4119,13 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 
 	function restoreDesiredThinking(ctx?: any) {
 		if (!desiredThinkingLevel) return;
+		internalThinkingChanges++;
 		try {
 			(pi as any).setThinkingLevel?.(desiredThinkingLevel);
 		} catch {
 			/* setThinkingLevel clamps to model caps; ignore if unsupported */
+		} finally {
+			internalThinkingChanges--;
 		}
 		// Record a clamp so the next turn does not mistake the fallback model's cap for intent.
 		const applied = readThinkingLevel();
@@ -6770,7 +6801,13 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	}
 
 	function rememberUserModel(model: { provider?: string; id?: string } | undefined) {
-		if (subagentChild || !model?.provider || !model?.id) return;
+		if (
+			subagentChild ||
+			!model?.provider ||
+			!model?.id ||
+			(hasExplicitCliSelection && !explicitCliSelectionChanged)
+		)
+			return;
 		const family = classifyProvider(model.provider, config.qwenProvider);
 		if (family) lastModelByFamily[family] = model.id;
 		persist(
@@ -6794,6 +6831,10 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			logEvent("remembered_model_skipped", { reason: "pi-subagents child owns model selection" });
 			return false;
 		}
+		if (explicitCli.model) {
+			logEvent("remembered_model_skipped", { reason: "explicit CLI model" });
+			return false;
+		}
 		const intended = intendedStartupModel();
 		if (!intended) {
 			logEvent("remembered_model_skipped", { reason: "no intended model" });
@@ -6803,7 +6844,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			ctx.model?.provider === intended.provider &&
 			ctx.model?.id === intended.id;
 		if (alreadyThere) {
-			restoreDesiredThinking(ctx);
+			if (!explicitCli.thinking) restoreDesiredThinking(ctx);
 			return true;
 		}
 		if (cursorReady) {
@@ -6844,11 +6885,13 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		if (ok) {
 			// Restore the user's level too — Pi clamped it to the fallback model's caps
 			// while creating the session.
-			const rememberedLevel = persistedState.lastUserThinkingLevel;
-			if (rememberedLevel) {
-				desiredThinkingLevel = rememberedLevel as ReasoningLevel;
+			if (!explicitCli.thinking) {
+				const rememberedLevel = persistedState.lastUserThinkingLevel;
+				if (rememberedLevel) {
+					desiredThinkingLevel = rememberedLevel as ReasoningLevel;
+				}
+				restoreDesiredThinking(ctx);
 			}
-			restoreDesiredThinking(ctx);
 			ctx.ui?.notify?.(
 				`pi-multi-account: restored ${to} after catalog load (Pi had fallen back to ${from})`,
 				"info",
@@ -7928,6 +7971,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 				) {
 					automaticModelTarget = same;
 					if (onlyActiveModels) unhideProvider(sourceModel.provider);
+					internalThinkingChanges++;
 					try {
 						await pi.setModel(
 							ctx.modelRegistry.find(sourceModel.provider, sourceModel.id) ?? {
@@ -7936,6 +7980,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 							},
 						);
 					} finally {
+						internalThinkingChanges--;
 						if (automaticModelTarget === same) automaticModelTarget = undefined;
 					}
 				}
@@ -10542,6 +10587,16 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		updateUsageStatus(ctx);
 	});
 
+	safeOn("thinking_level_select", (event, ctx) => {
+		if (subagentChild || internalThinkingChanges > 0) return;
+		const level = (event as any).level;
+		if (thinkingRank(level) < 0) return;
+		if (hasExplicitCliSelection) explicitCliSelectionChanged = true;
+		desiredThinkingLevel = level as ReasoningLevel;
+		thinkingClamp = undefined;
+		rememberUserModel(ctx?.model);
+	});
+
 	safeOn("model_select", (event, ctx) => {
 		const model = (event as any).model;
 		if (!model?.provider || !model?.id || subagentChild) return;
@@ -10559,6 +10614,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			return;
 		}
 		if ((event as any).source === "restore") return;
+		explicitCliSelectionChanged = true;
 		rememberUserModel(model);
 		// A manual model change is user control, not a permanent "never fail over" pin.
 		// Cancel stale pending work; if the selected model then returns a real limit, normal

--- a/index.ts
+++ b/index.ts
@@ -3551,47 +3551,59 @@ export function isSubagentChildProcess(
 	return env[SUBAGENT_CHILD_ENV] === "1";
 }
 
-function parseExplicitCliThinkingLevel(
-	argv: readonly string[] = process.argv,
-): ReasoningLevel | undefined {
-	let modelLevel: ReasoningLevel | undefined;
-	let thinkingLevel: ReasoningLevel | undefined;
+function parseExplicitCliArgs(argv: readonly string[] = process.argv): {
+	model?: string;
+	thinking?: ReasoningLevel;
+} {
+	let model: string | undefined;
+	let thinking: ReasoningLevel | undefined;
 	for (let i = 2; i < argv.length; i++) {
 		const arg = argv[i];
 		if (arg === "--") break;
-		if (arg === "--model" && i + 1 < argv.length) {
-			const value = argv[++i];
-			const colon = value.lastIndexOf(":");
-			const suffix = value.slice(colon + 1);
-			modelLevel =
-				colon >= 0 && REASONING_LEVELS.includes(suffix as ReasoningLevel)
-					? (suffix as ReasoningLevel)
-					: undefined;
-		} else if (arg === "--thinking" && i + 1 < argv.length) {
+		if (arg === "--model" && i + 1 < argv.length) model = argv[++i];
+		else if (arg === "--thinking" && i + 1 < argv.length) {
 			const value = argv[++i];
 			if (REASONING_LEVELS.includes(value as ReasoningLevel)) {
-				thinkingLevel = value as ReasoningLevel;
+				thinking = value as ReasoningLevel;
 			}
 		}
 	}
-	return thinkingLevel ?? modelLevel;
+	return { model, thinking };
+}
+
+// Pi checks the complete model pattern before treating its last colon token as thinking.
+// Registration has no session catalog, so reuse Pi's resolver once session_start supplies one.
+async function resolveExplicitCliModelThinkingLevel(
+	pattern: string | undefined,
+	ctx: any,
+): Promise<ReasoningLevel | undefined> {
+	if (!pattern) return undefined;
+	try {
+		const models = ctx?.modelRegistry?.getAll?.() ?? [];
+		const { resolveModelScopeWithDiagnostics } = await import(
+			"@earendil-works/pi-coding-agent"
+		);
+		const { scopedModels } = await resolveModelScopeWithDiagnostics(
+			[pattern],
+			{ getAvailable: async () => models } as any,
+		);
+		const level = scopedModels[0]?.thinkingLevel;
+		return REASONING_LEVELS.includes(level as ReasoningLevel)
+			? (level as ReasoningLevel)
+			: undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 export function explicitCliSelections(
 	argv: readonly string[] = process.argv,
 ): { model: boolean; thinking: boolean } {
-	let model = false;
-	for (let i = 2; i < argv.length; i++) {
-		const arg = argv[i];
-		if (arg === "--") break;
-		if (arg === "--model" && i + 1 < argv.length) {
-			model = true;
-			i++;
-		} else if (arg === "--thinking" && i + 1 < argv.length) {
-			i++;
-		}
-	}
-	return { model, thinking: parseExplicitCliThinkingLevel(argv) !== undefined };
+	const parsed = parseExplicitCliArgs(argv);
+	return {
+		model: parsed.model !== undefined,
+		thinking: parsed.thinking !== undefined,
+	};
 }
 
 export default function piMultiAccount(pi: ExtensionAPI) {
@@ -3603,8 +3615,13 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	// logins are unavailable, and the user is told once at session start.
 	const oauthUnavailable = piAiOauthUnavailableReason();
 	const subagentChild = isSubagentChildProcess();
-	const explicitCli = explicitCliSelections();
-	const explicitCliThinkingAtRegistration = parseExplicitCliThinkingLevel();
+	const explicitCliArgs = parseExplicitCliArgs();
+	const explicitCli = {
+		model: explicitCliArgs.model !== undefined,
+		thinking: explicitCliArgs.thinking !== undefined,
+	};
+	const explicitCliModelAtRegistration = explicitCliArgs.model;
+	const explicitCliThinkingAtRegistration = explicitCliArgs.thinking;
 	const hasExplicitCliSelection = explicitCli.model || explicitCli.thinking;
 	// A CLI launch owns both remembered dimensions until a genuine user change takes ownership
 	// of that dimension. Otherwise a model-only launch can persist its thinking clamp (or vice versa).
@@ -6748,6 +6765,10 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 				markExhausted(fallback.provider, config.transientCooldownMs);
 				failedProviders.add(fallback.provider);
 				continue;
+			}
+			if (options.manual) {
+				modelPreferenceChanged = true;
+				rememberUserModel(ctx.model ?? fallback);
 			}
 			restoreDesiredThinking(ctx);
 			applyOnlyActiveFilter(ctx, fallback.provider);
@@ -10353,6 +10374,17 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		pendingInternalThinkingChanges.length = 0;
 		activeInternalThinkingChange = undefined;
 		modelCatalogContext = ctx;
+		if (!explicitCliThinkingLevel) {
+			const resolved = await resolveExplicitCliModelThinkingLevel(
+				explicitCliModelAtRegistration,
+				ctx,
+			);
+			if (resolved) {
+				explicitCli.thinking = true;
+				explicitCliThinkingLevel = resolved;
+				desiredThinkingLevel = resolved;
+			}
+		}
 		if (!subagentChild) preflightHostCapabilities(ctx);
 		// Looked at BEFORE discovery touches anything, so what is judged is the files as Pi
 		// published them rather than the version our own slot provisioning has just rewritten.

--- a/index.ts
+++ b/index.ts
@@ -3554,20 +3554,27 @@ export function isSubagentChildProcess(
 function parseExplicitCliThinkingLevel(
 	argv: readonly string[] = process.argv,
 ): ReasoningLevel | undefined {
-	let level: ReasoningLevel | undefined;
+	let modelLevel: ReasoningLevel | undefined;
+	let thinkingLevel: ReasoningLevel | undefined;
 	for (let i = 2; i < argv.length; i++) {
 		const arg = argv[i];
 		if (arg === "--") break;
-		if (arg === "--model" || arg === "--thinking") {
-			if (i + 1 < argv.length) {
-				const value = argv[++i];
-				if (arg === "--thinking" && REASONING_LEVELS.includes(value as ReasoningLevel)) {
-					level = value as ReasoningLevel;
-				}
+		if (arg === "--model" && i + 1 < argv.length) {
+			const value = argv[++i];
+			const colon = value.lastIndexOf(":");
+			const suffix = value.slice(colon + 1);
+			modelLevel =
+				colon >= 0 && REASONING_LEVELS.includes(suffix as ReasoningLevel)
+					? (suffix as ReasoningLevel)
+					: undefined;
+		} else if (arg === "--thinking" && i + 1 < argv.length) {
+			const value = argv[++i];
+			if (REASONING_LEVELS.includes(value as ReasoningLevel)) {
+				thinkingLevel = value as ReasoningLevel;
 			}
 		}
 	}
-	return level;
+	return thinkingLevel ?? modelLevel;
 }
 
 export function explicitCliSelections(
@@ -4030,9 +4037,15 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	let userAbortedChain = false; // user pressed Esc → stop auto-continuing until a new prompt
 	let lastLeftProvider: string | undefined; // account we just failed away from (anti-ping-pong)
 	let lastLeftAt = 0;
+	type ThinkingChangeEvidence = {
+		model: string;
+		previousLevel: ReasoningLevel;
+		appliedLevel: ReasoningLevel;
+	};
 	let automaticModelTarget: ModelRef | undefined;
 	let lastObservedModelKey: string | undefined;
-	let pendingModelThinkingChange: { model: string; level: ReasoningLevel } | undefined;
+	let lastObservedThinkingLevel: ReasoningLevel | undefined;
+	let pendingModelThinkingChange: ThinkingChangeEvidence | undefined;
 	// Forward-progress watchdog state. A "resume in flight" is a continuation WE dispatched
 	// (pi.continueAgent after a switch) whose new turn must keep showing activity. Any stream
 	// token, tool event, or provider response is "progress" and disarms the stuck timer; total
@@ -4080,20 +4093,16 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	// read from the SESSION (per-agent `--thinking`, `/thinking`), not from a global default:
 	// forcing config.reasoningLevel on every agent_start clobbered per-agent thinking, so an
 	// agent configured `low` was flipped to `high` on its first turn (issue #6).
-	let desiredThinkingLevel: ReasoningLevel | undefined;
+	let desiredThinkingLevel: ReasoningLevel | undefined =
+		explicitCliThinkingAtRegistration;
 	let explicitCliThinkingLevel: ReasoningLevel | undefined = explicitCliThinkingAtRegistration;
 	// What the host applied after we asserted the session's intent, and on which model. A
 	// capability clamp or model default is NOT a user decision, otherwise thinking ratchets.
 	let thinkingClamp: { model: string; level: ReasoningLevel } | undefined;
-	type InternalThinkingChangeEvidence = {
-		model: string;
-		previousLevel: ReasoningLevel;
-		appliedLevel: ReasoningLevel;
-	};
-	const pendingInternalThinkingChanges: InternalThinkingChangeEvidence[] = [];
+	const pendingInternalThinkingChanges: ThinkingChangeEvidence[] = [];
 	const MAX_PENDING_INTERNAL_THINKING_CHANGES = 8;
 	let activeInternalThinkingChange:
-		| (Omit<InternalThinkingChangeEvidence, "appliedLevel"> & {
+		| (Omit<ThinkingChangeEvidence, "appliedLevel"> & {
 				appliedLevel?: ReasoningLevel;
 			})
 		| undefined;
@@ -4113,11 +4122,21 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 
 	if (explicitCli.thinking && !explicitCliThinkingLevel)
 		explicitCliThinkingLevel = readThinkingLevel();
+	if (explicitCli.thinking && explicitCliThinkingLevel)
+		desiredThinkingLevel = explicitCliThinkingLevel;
 
 	const thinkingModelKey = (ctx?: any) =>
 		ctx?.model?.provider && ctx?.model?.id
 			? ref(ctx.model.provider, ctx.model.id)
 			: "unknown";
+
+	function expectInternalThinkingChange(change: ThinkingChangeEvidence) {
+		pendingInternalThinkingChanges.push(change);
+		// Keep suppression one-shot and bounded. If the host stops delivering events, drop the
+		// oldest evidence instead of accumulating permanent future suppressions.
+		if (pendingInternalThinkingChanges.length > MAX_PENDING_INTERNAL_THINKING_CHANGES)
+			pendingInternalThinkingChanges.shift();
+	}
 
 	function consumeInternalThinkingChange(
 		event: any,
@@ -4205,16 +4224,13 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		// Record a clamp so the next turn does not mistake the fallback model's cap for intent.
 		const applied = readThinkingLevel();
 		if (!applied) return;
+		lastObservedThinkingLevel = applied;
 		if (
 			attempted &&
 			applied !== previousLevel &&
 			attempted.appliedLevel === undefined
 		) {
-			pendingInternalThinkingChanges.push({ ...attempted, appliedLevel: applied });
-			// Keep suppression one-shot and bounded. If the host stops delivering events, drop the
-			// oldest evidence instead of accumulating permanent future suppressions.
-			if (pendingInternalThinkingChanges.length > MAX_PENDING_INTERNAL_THINKING_CHANGES)
-				pendingInternalThinkingChanges.shift();
+			expectInternalThinkingChange({ ...attempted, appliedLevel: applied });
 		}
 		if (applied !== desiredThinkingLevel) {
 			thinkingClamp = { model: thinkingModelKey(ctx), level: applied };
@@ -10332,7 +10348,10 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 
 	safeOn("session_start", async (_event, ctx) => {
 		lastObservedModelKey = thinkingModelKey(ctx);
+		lastObservedThinkingLevel = readThinkingLevel();
 		pendingModelThinkingChange = undefined;
+		pendingInternalThinkingChanges.length = 0;
+		activeInternalThinkingChange = undefined;
 		modelCatalogContext = ctx;
 		if (!subagentChild) preflightHostCapabilities(ctx);
 		// Looked at BEFORE discovery touches anything, so what is judged is the files as Pi
@@ -10697,21 +10716,39 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		if (subagentChild) return;
 		const level = (event as any).level;
 		if (thinkingRank(level) < 0) return;
-		if (consumeInternalThinkingChange(event, ctx, level as ReasoningLevel)) return;
-		if (internalModelChanges > 0) return;
+		const appliedLevel = level as ReasoningLevel;
+		const previousLevel = (event as any).previousLevel;
+		const previouslyObserved = lastObservedThinkingLevel;
+		if (consumeInternalThinkingChange(event, ctx, appliedLevel)) {
+			lastObservedThinkingLevel = appliedLevel;
+			return;
+		}
+		if (internalModelChanges > 0) {
+			lastObservedThinkingLevel = appliedLevel;
+			return;
+		}
 		const modelKey = thinkingModelKey(ctx);
-		// Pi applies a model's thinking default/clamp before it emits model_select. The changed
-		// ctx.model identifies that one event; do not turn it into user intent.
+		// Pi changes ctx.model and applies its default/clamp before model_select. When this handler
+		// wins the fire-and-forget race, the old model and exact level transition identify that one
+		// native change. model_select handles the opposite order below.
 		if (
 			lastObservedModelKey &&
 			modelKey !== "unknown" &&
-			modelKey !== lastObservedModelKey
+			modelKey !== lastObservedModelKey &&
+			thinkingRank(previousLevel) >= 0 &&
+			previousLevel === previouslyObserved
 		) {
-			pendingModelThinkingChange = { model: modelKey, level: level as ReasoningLevel };
+			pendingModelThinkingChange = {
+				model: modelKey,
+				previousLevel,
+				appliedLevel,
+			};
+			lastObservedThinkingLevel = appliedLevel;
 			return;
 		}
+		lastObservedThinkingLevel = appliedLevel;
 		thinkingPreferenceChanged = true;
-		desiredThinkingLevel = level as ReasoningLevel;
+		desiredThinkingLevel = appliedLevel;
 		thinkingClamp = undefined;
 		rememberUserModel(ctx?.model);
 	});
@@ -10727,12 +10764,31 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			refreshUsage(ctx, model.provider),
 		);
 		const selected = ref(model.provider, model.id);
+		const appliedThinkingLevel = readThinkingLevel();
 		const pendingThinking = pendingModelThinkingChange;
 		pendingModelThinkingChange = undefined;
-		lastObservedModelKey = selected;
-		if (pendingThinking?.model === selected) {
-			thinkingClamp = pendingThinking;
+		if (
+			pendingThinking?.model === selected &&
+			(!appliedThinkingLevel || pendingThinking.appliedLevel === appliedThinkingLevel)
+		) {
+			thinkingClamp = {
+				model: selected,
+				level: pendingThinking.appliedLevel,
+			};
+		} else if (
+			appliedThinkingLevel &&
+			lastObservedThinkingLevel &&
+			appliedThinkingLevel !== lastObservedThinkingLevel
+		) {
+			expectInternalThinkingChange({
+				model: selected,
+				previousLevel: lastObservedThinkingLevel,
+				appliedLevel: appliedThinkingLevel,
+			});
+			thinkingClamp = { model: selected, level: appliedThinkingLevel };
 		}
+		if (appliedThinkingLevel) lastObservedThinkingLevel = appliedThinkingLevel;
+		lastObservedModelKey = selected;
 		if (automaticModelTarget === selected) {
 			automaticModelTarget = undefined;
 			rememberUserModel(model);

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@
  * State:   ~/.pi/agent/provider-failover-state.json
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
 import {
 	accessSync,
@@ -3553,14 +3554,17 @@ export function isSubagentChildProcess(
 
 function parseExplicitCliArgs(argv: readonly string[] = process.argv): {
 	model?: string;
+	provider?: string;
 	thinking?: ReasoningLevel;
 } {
 	let model: string | undefined;
+	let provider: string | undefined;
 	let thinking: ReasoningLevel | undefined;
 	for (let i = 2; i < argv.length; i++) {
 		const arg = argv[i];
 		if (arg === "--") break;
-		if (arg === "--model" && i + 1 < argv.length) model = argv[++i];
+		if (arg === "--provider" && i + 1 < argv.length) provider = argv[++i];
+		else if (arg === "--model" && i + 1 < argv.length) model = argv[++i];
 		else if (arg === "--thinking" && i + 1 < argv.length) {
 			const value = argv[++i];
 			if (REASONING_LEVELS.includes(value as ReasoningLevel)) {
@@ -3568,28 +3572,40 @@ function parseExplicitCliArgs(argv: readonly string[] = process.argv): {
 			}
 		}
 	}
-	return { model, thinking };
+	return { model, provider, thinking };
 }
 
-// Pi checks the complete model pattern before treating its last colon token as thinking.
-// Registration has no session catalog, so reuse Pi's resolver once session_start supplies one.
+// Registration has no model catalog. Once session_start supplies one, delegate model suffix
+// parsing to the same resolver as Pi's CLI, including exact colon IDs and provider custom IDs.
 async function resolveExplicitCliModelThinkingLevel(
-	pattern: string | undefined,
+	args: ReturnType<typeof parseExplicitCliArgs>,
 	ctx: any,
 ): Promise<ReasoningLevel | undefined> {
-	if (!pattern) return undefined;
+	if (!args.model) return undefined;
 	try {
-		const models = ctx?.modelRegistry?.getAll?.() ?? [];
-		const { resolveModelScopeWithDiagnostics } = await import(
+		const registry = ctx?.modelRegistry;
+		const models = registry?.getAll?.() ?? [];
+		const { resolveCliModel } = await import(
 			"@earendil-works/pi-coding-agent"
 		);
-		const { scopedModels } = await resolveModelScopeWithDiagnostics(
-			[pattern],
-			{ getAvailable: async () => models } as any,
-		);
-		const level = scopedModels[0]?.thinkingLevel;
-		return REASONING_LEVELS.includes(level as ReasoningLevel)
-			? (level as ReasoningLevel)
+		const { thinkingLevel } = resolveCliModel({
+			cliProvider: args.provider,
+			cliModel: args.model,
+			cliThinking: args.thinking,
+			modelRuntime: {
+				getModels: () => models,
+				hasConfiguredAuth: (provider: string) =>
+					models.some(
+						(model: any) =>
+							model.provider === provider &&
+							(registry.hasConfiguredAuth?.(model) ??
+								registry.getProviderAuthStatus?.(provider)?.configured ??
+								false),
+					),
+			} as any,
+		});
+		return REASONING_LEVELS.includes(thinkingLevel as ReasoningLevel)
+			? (thinkingLevel as ReasoningLevel)
 			: undefined;
 	} catch {
 		return undefined;
@@ -3620,7 +3636,6 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		model: explicitCliArgs.model !== undefined,
 		thinking: explicitCliArgs.thinking !== undefined,
 	};
-	const explicitCliModelAtRegistration = explicitCliArgs.model;
 	const explicitCliThinkingAtRegistration = explicitCliArgs.thinking;
 	const hasExplicitCliSelection = explicitCli.model || explicitCli.thinking;
 	// A CLI launch owns both remembered dimensions until a genuine user change takes ownership
@@ -4116,13 +4131,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 	// What the host applied after we asserted the session's intent, and on which model. A
 	// capability clamp or model default is NOT a user decision, otherwise thinking ratchets.
 	let thinkingClamp: { model: string; level: ReasoningLevel } | undefined;
-	const pendingInternalThinkingChanges: ThinkingChangeEvidence[] = [];
-	const MAX_PENDING_INTERNAL_THINKING_CHANGES = 8;
-	let activeInternalThinkingChange:
-		| (Omit<ThinkingChangeEvidence, "appliedLevel"> & {
-				appliedLevel?: ReasoningLevel;
-			})
-		| undefined;
+	const thinkingChangeSource = new AsyncLocalStorage<"extension">();
 
 	const thinkingRank = (level: unknown) =>
 		REASONING_LEVELS.indexOf(level as ReasoningLevel);
@@ -4146,46 +4155,6 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		ctx?.model?.provider && ctx?.model?.id
 			? ref(ctx.model.provider, ctx.model.id)
 			: "unknown";
-
-	function expectInternalThinkingChange(change: ThinkingChangeEvidence) {
-		pendingInternalThinkingChanges.push(change);
-		// Keep suppression one-shot and bounded. If the host stops delivering events, drop the
-		// oldest evidence instead of accumulating permanent future suppressions.
-		if (pendingInternalThinkingChanges.length > MAX_PENDING_INTERNAL_THINKING_CHANGES)
-			pendingInternalThinkingChanges.shift();
-	}
-
-	function consumeInternalThinkingChange(
-		event: any,
-		ctx: any,
-		appliedLevel: ReasoningLevel,
-	): boolean {
-		const previousLevel = event?.previousLevel;
-		if (thinkingRank(previousLevel) < 0) return false;
-		const model = thinkingModelKey(ctx);
-		const active = activeInternalThinkingChange;
-		// The first extension handler can run inside setThinkingLevel(), before the applied level
-		// is available to restoreDesiredThinking(). Reading it here completes the same exact key.
-		if (
-			active &&
-			active.model === model &&
-			active.previousLevel === previousLevel &&
-			readThinkingLevel() === appliedLevel
-		) {
-			active.appliedLevel = appliedLevel;
-			activeInternalThinkingChange = undefined;
-			return true;
-		}
-		const pending = pendingInternalThinkingChanges.findIndex(
-			(change) =>
-				change.model === model &&
-				change.previousLevel === previousLevel &&
-				change.appliedLevel === appliedLevel,
-		);
-		if (pending < 0) return false;
-		pendingInternalThinkingChanges.splice(pending, 1);
-		return true;
-	}
 
 	// A level lower than the intent that is exactly what the host produced last time we asserted
 	// the intent on THIS model is a clamp, not the user lowering thinking on purpose.
@@ -4225,30 +4194,17 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 
 	function restoreDesiredThinking(ctx?: any) {
 		if (!desiredThinkingLevel) return;
-		const previousLevel = readThinkingLevel();
-		const attempted: typeof activeInternalThinkingChange = previousLevel
-			? { model: thinkingModelKey(ctx), previousLevel }
-			: undefined;
-		if (attempted) activeInternalThinkingChange = attempted;
 		try {
-			(pi as any).setThinkingLevel?.(desiredThinkingLevel);
+			thinkingChangeSource.run("extension", () =>
+				(pi as any).setThinkingLevel?.(desiredThinkingLevel),
+			);
 		} catch {
 			/* setThinkingLevel clamps to model caps; ignore if unsupported */
-		} finally {
-			if (activeInternalThinkingChange === attempted)
-				activeInternalThinkingChange = undefined;
 		}
 		// Record a clamp so the next turn does not mistake the fallback model's cap for intent.
 		const applied = readThinkingLevel();
 		if (!applied) return;
 		lastObservedThinkingLevel = applied;
-		if (
-			attempted &&
-			applied !== previousLevel &&
-			attempted.appliedLevel === undefined
-		) {
-			expectInternalThinkingChange({ ...attempted, appliedLevel: applied });
-		}
 		if (applied !== desiredThinkingLevel) {
 			thinkingClamp = { model: thinkingModelKey(ctx), level: applied };
 			logEvent("thinking_clamped", {
@@ -10371,12 +10327,10 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		lastObservedModelKey = thinkingModelKey(ctx);
 		lastObservedThinkingLevel = readThinkingLevel();
 		pendingModelThinkingChange = undefined;
-		pendingInternalThinkingChanges.length = 0;
-		activeInternalThinkingChange = undefined;
 		modelCatalogContext = ctx;
 		if (!explicitCliThinkingLevel) {
 			const resolved = await resolveExplicitCliModelThinkingLevel(
-				explicitCliModelAtRegistration,
+				explicitCliArgs,
 				ctx,
 			);
 			if (resolved) {
@@ -10751,7 +10705,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		const appliedLevel = level as ReasoningLevel;
 		const previousLevel = (event as any).previousLevel;
 		const previouslyObserved = lastObservedThinkingLevel;
-		if (consumeInternalThinkingChange(event, ctx, appliedLevel)) {
+		if (thinkingChangeSource.getStore() === "extension") {
 			lastObservedThinkingLevel = appliedLevel;
 			return;
 		}
@@ -10760,6 +10714,15 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			return;
 		}
 		const modelKey = thinkingModelKey(ctx);
+		if (
+			pendingModelThinkingChange?.model === modelKey &&
+			pendingModelThinkingChange.previousLevel === previousLevel &&
+			pendingModelThinkingChange.appliedLevel === appliedLevel
+		) {
+			pendingModelThinkingChange = undefined;
+			lastObservedThinkingLevel = appliedLevel;
+			return;
+		}
 		// Pi changes ctx.model and applies its default/clamp before model_select. When this handler
 		// wins the fire-and-forget race, the old model and exact level transition identify that one
 		// native change. model_select handles the opposite order below.
@@ -10812,11 +10775,11 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			lastObservedThinkingLevel &&
 			appliedThinkingLevel !== lastObservedThinkingLevel
 		) {
-			expectInternalThinkingChange({
+			pendingModelThinkingChange = {
 				model: selected,
 				previousLevel: lastObservedThinkingLevel,
 				appliedLevel: appliedThinkingLevel,
-			});
+			};
 			thinkingClamp = { model: selected, level: appliedThinkingLevel };
 		}
 		if (appliedThinkingLevel) lastObservedThinkingLevel = appliedThinkingLevel;

--- a/index.ts
+++ b/index.ts
@@ -6678,6 +6678,11 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			if (failedProviders.has(fallback.provider)) continue;
 			const to = ref(fallback.provider, fallback.id);
 			if (to === from) {
+				if (options.manual && candidates.length === 1) {
+					modelPreferenceChanged = true;
+					rememberUserModel(sourceModel);
+					return true;
+				}
 				markExhausted(fallback.provider, config.transientCooldownMs);
 				failedProviders.add(fallback.provider);
 				continue;
@@ -9024,6 +9029,8 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 				candidates[0].provider === ctx.model.provider &&
 				candidates[0].id === ctx.model.id
 			) {
+				modelPreferenceChanged = true;
+				rememberUserModel(ctx.model);
 				ctx.ui.notify(
 					`pi-multi-account: already on the best available account (${ctx.model.provider}/${ctx.model.id})`,
 					"info",

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -88,6 +88,7 @@ function uninstallCursorProvider() {
 
 const {
 	default: piMultiAccount,
+	explicitCliSelections,
 	canPersistRefreshedCredentials,
 	mergeRefreshedCredentials,
 	modelIdentityKey,
@@ -95,6 +96,9 @@ const {
 	sameModelIdentity,
 } = (await import("../index.ts")) as {
 	default: (pi: any) => void;
+	explicitCliSelections: (
+		argv?: readonly string[],
+	) => { model: boolean; thinking: boolean };
 	canPersistRefreshedCredentials: (
 		authStorage: any,
 		authWritable?: () => boolean,
@@ -112,6 +116,21 @@ const {
 	) => Promise<boolean>;
 	sameModelIdentity: (a: string | undefined, b: string | undefined) => boolean;
 };
+
+test("explicit CLI selection detection follows Pi option parsing", () => {
+	assert.deepEqual(
+		explicitCliSelections(["node", "pi", "--model", "openai/gpt-5.5", "--thinking", "high"]),
+		{ model: true, thinking: true },
+	);
+	assert.deepEqual(
+		explicitCliSelections(["node", "pi", "--", "--model", "openai/gpt-5.5"]),
+		{ model: false, thinking: false },
+	);
+	assert.deepEqual(
+		explicitCliSelections(["node", "pi", "--models", "openai/*"]),
+		{ model: false, thinking: false },
+	);
+});
 
 test("model identity folds Cursor effort suffixes and the cursor- prefix", () => {
 	assert.equal(modelIdentityKey("cursor-grok-4.6-high"), "grok-4.6");
@@ -251,6 +270,8 @@ function setup(opts: {
 	settings?: { defaultProvider: string; defaultModel: string };
 	/** Simulate a child process launched by pi-subagents. */
 	subagentChild?: boolean;
+	/** Simulate Pi CLI arguments before the extension is loaded. */
+	cliArgs?: string[];
 	/**
 	 * Shape of the host's AuthStorage.
 	 *
@@ -540,11 +561,14 @@ function setup(opts: {
 	(pi as any).__testCompactFn = opts.compactFn;
 
 	const previousSubagentChild = process.env.PI_SUBAGENT_CHILD;
+	const previousArgv = process.argv;
 	if (opts.subagentChild) process.env.PI_SUBAGENT_CHILD = "1";
 	else delete process.env.PI_SUBAGENT_CHILD;
+	process.argv = ["node", "pi", ...(opts.cliArgs ?? [])];
 	try {
 		piMultiAccount(pi);
 	} finally {
+		process.argv = previousArgv;
 		if (previousSubagentChild === undefined) delete process.env.PI_SUBAGENT_CHILD;
 		else process.env.PI_SUBAGENT_CHILD = previousSubagentChild;
 	}
@@ -2940,6 +2964,160 @@ test("session_start restores lastUserModel after Pi falls back to anthropic/clau
 		`startup must put the session back on the last live model, not Pi's anthropic default; setModels=${t.rec.setModels.join(",")}`,
 	);
 	uninstallCursorProvider();
+});
+
+test("explicit CLI model wins over remembered startup state and is not remembered on shutdown", async () => {
+	const t = setup({
+		accounts: {
+			anthropic: { type: "oauth", access: "a", refresh: "ar" },
+			"openai-codex-account-2": {
+				type: "oauth",
+				access: "c",
+				refresh: "cr",
+				accountId: "codex-2",
+			},
+		},
+		current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+		thinkingLevel: "high",
+		config: { enabled: false },
+		cliArgs: ["--model", "openai-codex-account-2/gpt-5.5"],
+		seedState: {
+			stateVersion: 5,
+			lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+			lastUserThinkingLevel: "low",
+			lastModelByFamily: { anthropic: "claude-opus-4-8" },
+			lastSwitches: [],
+		},
+	});
+	await t.fire("session_start", { reason: "startup" });
+	assert.deepEqual(t.ctx.model, {
+		provider: "openai-codex-account-2",
+		id: "gpt-5.5",
+	});
+	assert.equal(t.thinkingLevel(), "high");
+	assert.ok(!t.rec.notifies.some((message) => message.includes("restored")));
+	await t.fire("session_shutdown");
+	assert.deepEqual(t.readState().lastUserModel, {
+		provider: "anthropic",
+		id: "claude-opus-4-8",
+	});
+	assert.equal(t.readState().lastUserThinkingLevel, "low");
+});
+
+test("explicit CLI thinking wins while ordinary model restoration remains enabled", async () => {
+	const t = setup({
+		accounts: {
+			anthropic: { type: "oauth", access: "a", refresh: "ar" },
+			"openai-codex-account-2": {
+				type: "oauth",
+				access: "c",
+				refresh: "cr",
+				accountId: "codex-2",
+			},
+		},
+		current: { provider: "anthropic", id: "claude-opus-4-8" },
+		thinkingLevel: "high",
+		config: { enabled: false },
+		cliArgs: ["--thinking", "high"],
+		seedState: {
+			stateVersion: 5,
+			lastUserModel: {
+				provider: "openai-codex-account-2",
+				id: "gpt-5.5",
+			},
+			lastUserThinkingLevel: "low",
+			lastModelByFamily: { "openai-codex": "gpt-5.5" },
+			lastSwitches: [],
+		},
+	});
+	await t.fire("session_start", { reason: "startup" });
+	assert.deepEqual(t.ctx.model, {
+		provider: "openai-codex-account-2",
+		id: "gpt-5.5",
+	});
+	assert.equal(t.thinkingLevel(), "high");
+	assert.deepEqual(t.rec.thinkingLevels, []);
+	await t.fire("session_shutdown");
+	assert.equal(t.readState().lastUserThinkingLevel, "low");
+});
+
+test("no-session explicit launch neither restores nor overwrites the global preference", async () => {
+	const t = setup({
+		accounts: {
+			anthropic: { type: "oauth", access: "a", refresh: "ar" },
+			"openai-codex-account-2": {
+				type: "oauth",
+				access: "c",
+				refresh: "cr",
+				accountId: "codex-2",
+			},
+		},
+		current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+		thinkingLevel: "high",
+		config: { enabled: false },
+		cliArgs: [
+			"--no-session",
+			"--model",
+			"openai-codex-account-2/gpt-5.5",
+			"--thinking",
+			"high",
+		],
+		seedState: {
+			stateVersion: 5,
+			lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+			lastUserThinkingLevel: "low",
+			lastModelByFamily: { anthropic: "claude-opus-4-8" },
+			lastSwitches: [],
+		},
+	});
+	await t.fire("session_start", { reason: "startup" });
+	assert.deepEqual(t.ctx.model, {
+		provider: "openai-codex-account-2",
+		id: "gpt-5.5",
+	});
+	await t.fire("session_shutdown");
+	assert.deepEqual(t.readState().lastUserModel, {
+		provider: "anthropic",
+		id: "claude-opus-4-8",
+	});
+	assert.equal(t.readState().lastUserThinkingLevel, "low");
+});
+
+test("explicit CLI preference can be replaced by a genuine user model selection", async () => {
+	const t = setup({
+		accounts: {
+			anthropic: { type: "oauth", access: "a", refresh: "ar" },
+			"openai-codex-account-2": {
+				type: "oauth",
+				access: "c",
+				refresh: "cr",
+				accountId: "codex-2",
+			},
+		},
+		current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+		thinkingLevel: "high",
+		config: { enabled: false },
+		cliArgs: ["--model", "openai-codex-account-2/gpt-5.5"],
+		seedState: {
+			stateVersion: 5,
+			lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+			lastUserThinkingLevel: "low",
+			lastModelByFamily: { anthropic: "claude-opus-4-8" },
+			lastSwitches: [],
+		},
+	});
+	await t.fire("session_start", { reason: "startup" });
+	t.setCurrent("anthropic", "claude-opus-4-8");
+	await t.fire("model_select", {
+		model: { provider: "anthropic", id: "claude-opus-4-8" },
+		previousModel: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+		source: "set",
+	});
+	await t.fire("session_shutdown");
+	assert.deepEqual(t.readState().lastUserModel, {
+		provider: "anthropic",
+		id: "claude-opus-4-8",
+	});
 });
 
 test("pi-subagents child keeps its explicit launch model and delegates fallback to the parent runner", async () => {

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -420,7 +420,10 @@ function setup(opts: {
 	const events: Record<string, Array<(event: any, ctx?: any) => any>> = {};
 	const busEvents = new Map<string, Array<(payload: any) => void>>();
 	const commands: Record<string, (args: string, ctx: any) => any> = {};
-	const pendingThinkingLevelSelects: Promise<void>[] = [];
+	const pendingThinkingLevelSelects: Array<{
+		delivery: Promise<void>;
+		release?: () => void;
+	}> = [];
 
 	const ctx: any = {
 		model: opts.current
@@ -532,12 +535,18 @@ function setup(opts: {
 		payload: { level: string; previousLevel: string },
 		delayed = opts.thinkingLevelSelectDelivery === "delayed",
 	) => {
+		let release: (() => void) | undefined;
+		const gate = delayed
+			? new Promise<void>((resolve) => {
+					release = resolve;
+				})
+			: undefined;
 		const delivery = (async () => {
-			if (delayed) await Promise.resolve();
+			if (gate) await gate;
 			for (const handler of events.thinking_level_select ?? [])
 				await handler(payload, ctx);
 		})();
-		pendingThinkingLevelSelects.push(delivery);
+		pendingThinkingLevelSelects.push({ delivery, release });
 		return delivery;
 	};
 
@@ -725,8 +734,11 @@ function setup(opts: {
 		sessionThinkingLevel = clampThinking(level);
 	};
 	const settleThinkingLevelSelects = async () => {
-		while (pendingThinkingLevelSelects.length > 0)
-			await Promise.all(pendingThinkingLevelSelects.splice(0));
+		while (pendingThinkingLevelSelects.length > 0) {
+			const pending = pendingThinkingLevelSelects.splice(0);
+			for (const item of pending) item.release?.();
+			await Promise.all(pending.map((item) => item.delivery));
+		}
 	};
 
 	return {
@@ -3114,11 +3126,18 @@ test("explicit CLI model thinking is catalog-resolved before startup fallback", 
 			expectedThinking: "high",
 		},
 		{
-			name: "a valid suffix does not apply to an unmatched base",
-			models: ["another-model"],
-			currentId: base,
-			cliArgs: ["--model", `${provider}/${base}:high`],
-			expectedThinking: "low",
+			name: "a valid suffix applies to a recognized-provider custom model",
+			models: [base],
+			currentId: "future-model",
+			cliArgs: ["--model", `${provider}/future-model:high`],
+			expectedThinking: "high",
+		},
+		{
+			name: "--provider custom model shorthand follows the same resolution",
+			models: [base],
+			currentId: "future-model",
+			cliArgs: ["--provider", provider, "--model", "future-model:high"],
+			expectedThinking: "high",
 		},
 		{
 			name: "an invalid suffix is not a thinking override",
@@ -3132,6 +3151,13 @@ test("explicit CLI model thinking is catalog-resolved before startup fallback", 
 			models: [base],
 			currentId: base,
 			cliArgs: ["--thinking", "high", "--model", `${provider}/${base}:low`],
+			expectedThinking: "high",
+		},
+		{
+			name: "invalid standalone --thinking does not suppress model shorthand",
+			models: [base],
+			currentId: base,
+			cliArgs: ["--thinking", "invalid", "--model", `${provider}/${base}:high`],
 			expectedThinking: "high",
 		},
 	]) {
@@ -3224,7 +3250,6 @@ test("internal thinking restores do not become explicit CLI intent", async (suit
 				},
 			});
 			await t.fire("session_start", { reason: "startup" });
-			await t.settleThinkingLevelSelects();
 			assert.equal(t.thinkingLevel(), "high");
 			assert.equal(
 				t.readState().lastUserThinkingLevel,
@@ -3232,7 +3257,7 @@ test("internal thinking restores do not become explicit CLI intent", async (suit
 				"the extension's own restore must not persist the one-shot CLI level",
 			);
 
-			// Recreate the exact low -> high event key after the internal event was consumed.
+			// For delayed delivery, make the genuine identical low -> high transition arrive first.
 			t.userSetsThinking("low");
 			await t.fire("thinking_level_select", {
 				level: "low",
@@ -3243,6 +3268,12 @@ test("internal thinking restores do not become explicit CLI intent", async (suit
 				level: "high",
 				previousLevel: "low",
 			});
+			assert.equal(
+				t.readState().lastUserThinkingLevel,
+				"high",
+				"the genuine identical choice must be recorded before delayed internal delivery",
+			);
+			await t.settleThinkingLevelSelects();
 			await t.fire("session_shutdown");
 			assert.equal(
 				t.readState().lastUserThinkingLevel,

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -119,7 +119,14 @@ const {
 
 test("explicit CLI selection detection follows Pi option parsing", () => {
 	assert.deepEqual(
-		explicitCliSelections(["node", "pi", "--model", "openai/gpt-5.5", "--thinking", "high"]),
+		explicitCliSelections([
+			"node",
+			"pi",
+			"--model",
+			"openai/gpt-5.5",
+			"--thinking",
+			"high",
+		]),
 		{ model: true, thinking: true },
 	);
 	for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max"]) {
@@ -127,17 +134,35 @@ test("explicit CLI selection detection follows Pi option parsing", () => {
 			explicitCliSelections(["node", "pi", "--thinking", level]).thinking,
 			true,
 		);
+		assert.deepEqual(
+			explicitCliSelections([
+				"node",
+				"pi",
+				"--model",
+				`openrouter/acme:model/v1.2+fast@2026-09-01:${level}`,
+			]),
+			{ model: true, thinking: true },
+		);
 	}
 	assert.deepEqual(
 		explicitCliSelections(["node", "pi", "--thinking", "invalid"]),
 		{ model: false, thinking: false },
 	);
 	assert.deepEqual(
-		explicitCliSelections(["node", "pi", "--", "--model", "openai/gpt-5.5"]),
+		explicitCliSelections([
+			"node",
+			"pi",
+			"--model",
+			"openrouter/acme:model/v1.2+fast@2026-09-01:turbo",
+		]),
+		{ model: true, thinking: false },
+	);
+	assert.deepEqual(
+		explicitCliSelections(["node", "pi", "--", "--model", "openai/gpt-5.5:high"]),
 		{ model: false, thinking: false },
 	);
 	assert.deepEqual(
-		explicitCliSelections(["node", "pi", "--models", "openai/*"]),
+		explicitCliSelections(["node", "pi", "--models", "openai/*:high"]),
 		{ model: false, thinking: false },
 	);
 });
@@ -276,6 +301,8 @@ function setup(opts: {
 	thinkingLevel?: string;
 	/** Thinking level Pi applies while changing models, before model_select is emitted. */
 	modelSetThinkingLevel?: string;
+	/** Deliver a model-induced thinking event before or after model_select. */
+	modelThinkingLevelSelectDelivery?: "before" | "after";
 	/** Emit setThinkingLevel's fire-and-forget host event, optionally after a prior-handler yield. */
 	thinkingLevelSelectDelivery?: "sync" | "delayed";
 	/** Highest thinking level a provider's models support — Pi clamps anything above it. */
@@ -500,17 +527,17 @@ function setup(opts: {
 		getContextUsage: () => opts.contextUsage,
 	};
 
-	const dispatchThinkingLevelSelect = (payload: {
-		level: string;
-		previousLevel: string;
-	}) => {
+	const dispatchThinkingLevelSelect = (
+		payload: { level: string; previousLevel: string },
+		delayed = opts.thinkingLevelSelectDelivery === "delayed",
+	) => {
 		const delivery = (async () => {
-			if (opts.thinkingLevelSelectDelivery === "delayed")
-				await Promise.resolve();
+			if (delayed) await Promise.resolve();
 			for (const handler of events.thinking_level_select ?? [])
 				await handler(payload, ctx);
 		})();
 		pendingThinkingLevelSelects.push(delivery);
+		return delivery;
 	};
 
 	const pi: any = {
@@ -558,11 +585,16 @@ function setup(opts: {
 			const previousThinkingLevel = sessionThinkingLevel;
 			sessionThinkingLevel = opts.modelSetThinkingLevel ?? clampThinking(sessionThinkingLevel);
 			if (sessionThinkingLevel !== previousThinkingLevel) {
-				for (const handler of events.thinking_level_select ?? [])
-					await handler(
-						{ level: sessionThinkingLevel, previousLevel: previousThinkingLevel },
-						ctx,
-					);
+				const payload = {
+					level: sessionThinkingLevel,
+					previousLevel: previousThinkingLevel,
+				};
+				if (opts.modelThinkingLevelSelectDelivery === "after") {
+					dispatchThinkingLevelSelect(payload, true);
+				} else {
+					for (const handler of events.thinking_level_select ?? [])
+						await handler(payload, ctx);
+				}
 			}
 			for (const handler of events.model_select ?? [])
 				await handler({ model: ctx.model, previousModel, source: "set" }, ctx);
@@ -3062,6 +3094,40 @@ test("explicit CLI model wins over remembered startup state and is not remembere
 	assert.equal(t.readState().lastUserThinkingLevel, "low");
 });
 
+test("explicit CLI thinking survives a startup fallback before agent_start", async (suite) => {
+	const model = "missing.provider/acme:model/v1.2+fast@2026-09-01";
+	for (const { name, cliArgs } of [
+		{ name: "model shorthand", cliArgs: ["--model", `${model}:high`] },
+		{
+			name: "standalone thinking precedence",
+			cliArgs: ["--thinking", "high", "--model", `${model}:low`],
+		},
+	]) {
+		await suite.test(name, async () => {
+			const t = setup({
+				accounts: {
+					anthropic: { type: "oauth", access: "a", refresh: "ar" },
+				},
+				current: {
+					provider: "missing.provider",
+					id: "acme:model/v1.2+fast@2026-09-01",
+				},
+				thinkingLevel: "high",
+				modelSetThinkingLevel: "low",
+				config: { fallbacks: ["anthropic"] },
+				cliArgs,
+			});
+			await t.fire("session_start", { reason: "startup" });
+			assert.equal(t.ctx.model.provider, "anthropic");
+			assert.equal(
+				t.thinkingLevel(),
+				"high",
+				"the explicit level must survive fallback before agent_start can capture it",
+			);
+		});
+	}
+});
+
 test("explicit CLI thinking wins while ordinary model restoration remains enabled", async () => {
 	const t = setup({
 		accounts: {
@@ -3155,39 +3221,66 @@ test("internal thinking restores do not become explicit CLI intent", async (suit
 	}
 });
 
-test("explicit CLI model keeps a native model thinking reset out of remembered state", async () => {
-	const t = setup({
-		accounts: {
-			anthropic: { type: "oauth", access: "a", refresh: "ar" },
-			"openai-codex-account-2": {
-				type: "oauth",
-				access: "c",
-				refresh: "cr",
-				accountId: "codex-2",
-			},
-		},
-		current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
-		thinkingLevel: "high",
-		modelSetThinkingLevel: "low",
-		config: { enabled: false },
-		cliArgs: ["--model", "openai-codex-account-2/gpt-5.5"],
-		seedState: {
-			stateVersion: 5,
-			lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
-			lastUserThinkingLevel: "high",
-			lastModelByFamily: { anthropic: "claude-opus-4-8" },
-			lastSwitches: [],
-		},
-	});
-	await t.fire("session_start", { reason: "startup" });
-	await t.setModel("anthropic", "claude-opus-4-8");
-	assert.equal(t.thinkingLevel(), "low");
-	await t.fire("session_shutdown");
-	assert.deepEqual(t.readState().lastUserModel, {
-		provider: "anthropic",
-		id: "claude-opus-4-8",
-	});
-	assert.equal(t.readState().lastUserThinkingLevel, "high");
+test("native model thinking resets do not become explicit CLI intent", async (suite) => {
+	for (const delivery of ["before", "after"] as const) {
+		await suite.test(`${delivery} model_select delivery`, async () => {
+			const t = setup({
+				accounts: {
+					anthropic: { type: "oauth", access: "a", refresh: "ar" },
+					"openai-codex-account-2": {
+						type: "oauth",
+						access: "c",
+						refresh: "cr",
+						accountId: "codex-2",
+					},
+				},
+				current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+				thinkingLevel: "high",
+				modelSetThinkingLevel: "low",
+				modelThinkingLevelSelectDelivery: delivery,
+				config: { enabled: false },
+				cliArgs: ["--model", "openai-codex-account-2/gpt-5.5"],
+				seedState: {
+					stateVersion: 5,
+					lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+					lastUserThinkingLevel: "high",
+					lastModelByFamily: { anthropic: "claude-opus-4-8" },
+					lastSwitches: [],
+				},
+			});
+			await t.fire("session_start", { reason: "startup" });
+			await t.setModel("anthropic", "claude-opus-4-8");
+			await t.settleThinkingLevelSelects();
+			assert.equal(t.thinkingLevel(), "low");
+			assert.equal(
+				t.readState().lastUserThinkingLevel,
+				"high",
+				"the model's native reset must not become remembered user intent",
+			);
+
+			// Recreate the same high -> low key after its one-shot evidence was consumed.
+			t.userSetsThinking("high");
+			await t.fire("thinking_level_select", {
+				level: "high",
+				previousLevel: "low",
+			});
+			t.userSetsThinking("low");
+			await t.fire("thinking_level_select", {
+				level: "low",
+				previousLevel: "high",
+			});
+			await t.fire("session_shutdown");
+			assert.deepEqual(t.readState().lastUserModel, {
+				provider: "anthropic",
+				id: "claude-opus-4-8",
+			});
+			assert.equal(
+				t.readState().lastUserThinkingLevel,
+				"low",
+				"a later genuine identical choice must not be hidden",
+			);
+		});
+	}
 });
 
 test("explicit CLI model can be replaced by a genuine thinking selection only", async () => {

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -122,6 +122,16 @@ test("explicit CLI selection detection follows Pi option parsing", () => {
 		explicitCliSelections(["node", "pi", "--model", "openai/gpt-5.5", "--thinking", "high"]),
 		{ model: true, thinking: true },
 	);
+	for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max"]) {
+		assert.equal(
+			explicitCliSelections(["node", "pi", "--thinking", level]).thinking,
+			true,
+		);
+	}
+	assert.deepEqual(
+		explicitCliSelections(["node", "pi", "--thinking", "invalid"]),
+		{ model: false, thinking: false },
+	);
 	assert.deepEqual(
 		explicitCliSelections(["node", "pi", "--", "--model", "openai/gpt-5.5"]),
 		{ model: false, thinking: false },
@@ -264,6 +274,8 @@ function setup(opts: {
 	unknownProviders?: string[];
 	/** The level the SESSION runs at (what `--thinking` / `/thinking` produced). */
 	thinkingLevel?: string;
+	/** Thinking level Pi applies while changing models, before model_select is emitted. */
+	modelSetThinkingLevel?: string;
 	/** Highest thinking level a provider's models support — Pi clamps anything above it. */
 	thinkingCaps?: Record<string, string>;
 	/** Pi settings.json defaultProvider/defaultModel, used after catalog load. */
@@ -526,8 +538,16 @@ function setup(opts: {
 			rec.setModels.push(target);
 			if (opts.setModelFailures?.includes(target)) return false;
 			ctx.model = mkModel(model.provider, model.id);
-			// Pi re-clamps (and persists) the thinking level for the new model's capabilities.
-			sessionThinkingLevel = clampThinking(sessionThinkingLevel);
+			// Pi applies a model default/clamp before emitting model_select.
+			const previousThinkingLevel = sessionThinkingLevel;
+			sessionThinkingLevel = opts.modelSetThinkingLevel ?? clampThinking(sessionThinkingLevel);
+			if (sessionThinkingLevel !== previousThinkingLevel) {
+				for (const handler of events.thinking_level_select ?? [])
+					await handler(
+						{ level: sessionThinkingLevel, previousLevel: previousThinkingLevel },
+						ctx,
+					);
+			}
 			for (const handler of events.model_select ?? [])
 				await handler({ model: ctx.model, previousModel, source: "set" }, ctx);
 			return true;
@@ -616,6 +636,8 @@ function setup(opts: {
 	const setCurrent = (provider: string, id: string) => {
 		ctx.model = mkModel(provider, id);
 	};
+	const setModel = (provider: string, id: string) =>
+		pi.setModel(mkModel(provider, id));
 	const readState = () => {
 		try {
 			return JSON.parse(readFileSync(STATE, "utf8"));
@@ -650,6 +672,7 @@ function setup(opts: {
 		fire,
 		setIdle,
 		setCurrent,
+		setModel,
 		readState,
 		beforeReq,
 		command,
@@ -2946,10 +2969,13 @@ test("session_start restores lastUserModel after Pi falls back to anthropic/clau
 			cursor: { type: "oauth", access: "c", refresh: "cr" },
 		},
 		current: { provider: "anthropic", id: "claude-opus-4-8" },
+		thinkingLevel: "high",
+		modelSetThinkingLevel: "low",
 		config: { includeCursor: true, fallbacks: ["anthropic", "cursor"] },
 		seedState: {
 			stateVersion: 5,
 			lastUserModel: { provider: "cursor", id: "cursor-grok-4.6" },
+			lastUserThinkingLevel: "high",
 			lastModelByFamily: { cursor: "cursor-grok-4.6" },
 			exhaustedUntilByProvider: {},
 			lastProbeAtByProvider: {},
@@ -2963,6 +2989,7 @@ test("session_start restores lastUserModel after Pi falls back to anthropic/clau
 		{ provider: "cursor", id: "cursor-grok-4.6" },
 		`startup must put the session back on the last live model, not Pi's anthropic default; setModels=${t.rec.setModels.join(",")}`,
 	);
+	assert.equal(t.thinkingLevel(), "high");
 	uninstallCursorProvider();
 });
 
@@ -3017,6 +3044,7 @@ test("explicit CLI thinking wins while ordinary model restoration remains enable
 		},
 		current: { provider: "anthropic", id: "claude-opus-4-8" },
 		thinkingLevel: "high",
+		modelSetThinkingLevel: "low",
 		config: { enabled: false },
 		cliArgs: ["--thinking", "high"],
 		seedState: {
@@ -3025,7 +3053,7 @@ test("explicit CLI thinking wins while ordinary model restoration remains enable
 				provider: "openai-codex-account-2",
 				id: "gpt-5.5",
 			},
-			lastUserThinkingLevel: "low",
+			lastUserThinkingLevel: "medium",
 			lastModelByFamily: { "openai-codex": "gpt-5.5" },
 			lastSwitches: [],
 		},
@@ -3036,9 +3064,86 @@ test("explicit CLI thinking wins while ordinary model restoration remains enable
 		id: "gpt-5.5",
 	});
 	assert.equal(t.thinkingLevel(), "high");
-	assert.deepEqual(t.rec.thinkingLevels, []);
+	assert.deepEqual(t.rec.thinkingLevels, ["high"]);
+	await t.setModel("anthropic", "claude-opus-4-8");
 	await t.fire("session_shutdown");
-	assert.equal(t.readState().lastUserThinkingLevel, "low");
+	assert.deepEqual(t.readState().lastUserModel, {
+		provider: "anthropic",
+		id: "claude-opus-4-8",
+	});
+	assert.equal(t.readState().lastUserThinkingLevel, "medium");
+});
+
+test("explicit CLI model keeps a native model thinking reset out of remembered state", async () => {
+	const t = setup({
+		accounts: {
+			anthropic: { type: "oauth", access: "a", refresh: "ar" },
+			"openai-codex-account-2": {
+				type: "oauth",
+				access: "c",
+				refresh: "cr",
+				accountId: "codex-2",
+			},
+		},
+		current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+		thinkingLevel: "high",
+		modelSetThinkingLevel: "low",
+		config: { enabled: false },
+		cliArgs: ["--model", "openai-codex-account-2/gpt-5.5"],
+		seedState: {
+			stateVersion: 5,
+			lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+			lastUserThinkingLevel: "high",
+			lastModelByFamily: { anthropic: "claude-opus-4-8" },
+			lastSwitches: [],
+		},
+	});
+	await t.fire("session_start", { reason: "startup" });
+	await t.setModel("anthropic", "claude-opus-4-8");
+	assert.equal(t.thinkingLevel(), "low");
+	await t.fire("session_shutdown");
+	assert.deepEqual(t.readState().lastUserModel, {
+		provider: "anthropic",
+		id: "claude-opus-4-8",
+	});
+	assert.equal(t.readState().lastUserThinkingLevel, "high");
+});
+
+test("explicit CLI model can be replaced by a genuine thinking selection only", async () => {
+	const t = setup({
+		accounts: {
+			anthropic: { type: "oauth", access: "a", refresh: "ar" },
+			"openai-codex-account-2": {
+				type: "oauth",
+				access: "c",
+				refresh: "cr",
+				accountId: "codex-2",
+			},
+		},
+		current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+		thinkingLevel: "high",
+		config: { enabled: false },
+		cliArgs: ["--model", "openai-codex-account-2/gpt-5.5"],
+		seedState: {
+			stateVersion: 5,
+			lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+			lastUserThinkingLevel: "low",
+			lastModelByFamily: { anthropic: "claude-opus-4-8" },
+			lastSwitches: [],
+		},
+	});
+	await t.fire("session_start", { reason: "startup" });
+	t.userSetsThinking("medium");
+	await t.fire("thinking_level_select", {
+		level: "medium",
+		previousLevel: "high",
+	});
+	await t.fire("session_shutdown");
+	assert.deepEqual(t.readState().lastUserModel, {
+		provider: "anthropic",
+		id: "claude-opus-4-8",
+	});
+	assert.equal(t.readState().lastUserThinkingLevel, "medium");
 });
 
 test("no-session explicit launch neither restores nor overwrites the global preference", async () => {

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -3500,6 +3500,39 @@ test("manual rotation commands own the model preference after an explicit CLI la
 	}
 });
 
+test("manual no-op choices own the model preference after an explicit CLI launch", async (suite) => {
+	for (const command of ["best", "switch openai-codex-account-2/gpt-5.5"]) {
+		await suite.test(command, async () => {
+			const current = { provider: "openai-codex-account-2", id: "gpt-5.5" };
+			const t = setup({
+				accounts: {
+					"openai-codex-account-2": {
+						type: "oauth",
+						access: "c",
+						refresh: "cr",
+						accountId: "codex-2",
+					},
+				},
+				current,
+				thinkingLevel: "high",
+				cliArgs: ["--model", `${current.provider}/${current.id}`],
+				seedState: {
+					stateVersion: 5,
+					lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+					lastUserThinkingLevel: "low",
+					lastModelByFamily: { anthropic: "claude-opus-4-8" },
+					lastSwitches: [],
+				},
+			});
+			await t.fire("session_start", { reason: "startup" });
+			await t.command(command);
+			await t.fire("session_shutdown");
+			assert.deepEqual(t.readState().lastUserModel, current);
+			assert.equal(t.readState().lastUserThinkingLevel, "low");
+		});
+	}
+});
+
 test("pi-subagents child keeps its explicit launch model and delegates fallback to the parent runner", async () => {
 	const t = setup({
 		accounts: {

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -134,16 +134,17 @@ test("explicit CLI selection detection follows Pi option parsing", () => {
 			explicitCliSelections(["node", "pi", "--thinking", level]).thinking,
 			true,
 		);
-		assert.deepEqual(
-			explicitCliSelections([
-				"node",
-				"pi",
-				"--model",
-				`openrouter/acme:model/v1.2+fast@2026-09-01:${level}`,
-			]),
-			{ model: true, thinking: true },
-		);
 	}
+	assert.deepEqual(
+		explicitCliSelections([
+			"node",
+			"pi",
+			"--model",
+			"openrouter/acme:model/v1.2+fast@2026-09-01:high",
+		]),
+		{ model: true, thinking: false },
+		"a model suffix cannot be classified until the session catalog is available",
+	);
 	assert.deepEqual(
 		explicitCliSelections(["node", "pi", "--thinking", "invalid"]),
 		{ model: false, thinking: false },
@@ -3094,36 +3095,67 @@ test("explicit CLI model wins over remembered startup state and is not remembere
 	assert.equal(t.readState().lastUserThinkingLevel, "low");
 });
 
-test("explicit CLI thinking survives a startup fallback before agent_start", async (suite) => {
-	const model = "missing.provider/acme:model/v1.2+fast@2026-09-01";
-	for (const { name, cliArgs } of [
-		{ name: "model shorthand", cliArgs: ["--model", `${model}:high`] },
+test("explicit CLI model thinking is catalog-resolved before startup fallback", async (suite) => {
+	const provider = "openai-codex";
+	const base = "acme:model/v1.2+fast@2026-09-01";
+	for (const scenario of [
 		{
-			name: "standalone thinking precedence",
-			cliArgs: ["--thinking", "high", "--model", `${model}:low`],
+			name: "a complete real model ID ending in :high wins",
+			models: [`${base}:high`],
+			currentId: `${base}:high`,
+			cliArgs: ["--model", `${provider}/${base}:high`],
+			expectedThinking: "low",
+		},
+		{
+			name: "a valid suffix applies when the stripped model resolves",
+			models: [base],
+			currentId: base,
+			cliArgs: ["--model", `${provider}/${base}:high`],
+			expectedThinking: "high",
+		},
+		{
+			name: "a valid suffix does not apply to an unmatched base",
+			models: ["another-model"],
+			currentId: base,
+			cliArgs: ["--model", `${provider}/${base}:high`],
+			expectedThinking: "low",
+		},
+		{
+			name: "an invalid suffix is not a thinking override",
+			models: [base],
+			currentId: `${base}:turbo`,
+			cliArgs: ["--model", `${provider}/${base}:turbo`],
+			expectedThinking: "low",
+		},
+		{
+			name: "standalone --thinking takes precedence",
+			models: [base],
+			currentId: base,
+			cliArgs: ["--thinking", "high", "--model", `${provider}/${base}:low`],
+			expectedThinking: "high",
 		},
 	]) {
-		await suite.test(name, async () => {
+		await suite.test(scenario.name, async () => {
 			const t = setup({
 				accounts: {
+					[provider]: { type: "api_key" },
 					anthropic: { type: "oauth", access: "a", refresh: "ar" },
 				},
-				current: {
-					provider: "missing.provider",
-					id: "acme:model/v1.2+fast@2026-09-01",
-				},
-				thinkingLevel: "high",
+				hostCodexModels: scenario.models,
+				current: { provider, id: scenario.currentId },
+				thinkingLevel: "medium",
 				modelSetThinkingLevel: "low",
 				config: { fallbacks: ["anthropic"] },
-				cliArgs,
+				cliArgs: scenario.cliArgs,
 			});
 			await t.fire("session_start", { reason: "startup" });
-			assert.equal(t.ctx.model.provider, "anthropic");
 			assert.equal(
-				t.thinkingLevel(),
-				"high",
-				"the explicit level must survive fallback before agent_start can capture it",
+				t.ctx.model.provider,
+				"anthropic",
+				"the unavailable launch model must fall back before agent_start",
 			);
+			assert.equal(t.thinkingLevel(), scenario.expectedThinking);
+			await t.fire("session_shutdown");
 		});
 	}
 });
@@ -3397,6 +3429,44 @@ test("explicit CLI preference can be replaced by a genuine user model selection"
 		provider: "anthropic",
 		id: "claude-opus-4-8",
 	});
+});
+
+test("manual rotation commands own the model preference after an explicit CLI launch", async (suite) => {
+	for (const command of ["next", "switch anthropic", "best"]) {
+		await suite.test(command, async () => {
+			const t = setup({
+				accounts: {
+					anthropic: { type: "oauth", access: "a", refresh: "ar" },
+					"openai-codex-account-2": {
+						type: "oauth",
+						access: "c",
+						refresh: "cr",
+						accountId: "codex-2",
+					},
+				},
+				current: { provider: "openai-codex-account-2", id: "gpt-5.5" },
+				thinkingLevel: "high",
+				cliArgs: ["--model", "openai-codex-account-2/gpt-5.5"],
+				seedState: {
+					stateVersion: 5,
+					lastUserModel: { provider: "alibaba", id: "qwen3.7-max" },
+					lastUserThinkingLevel: "low",
+					lastModelByFamily: { qwen: "qwen3.7-max" },
+					lastSwitches: [],
+				},
+			});
+			await t.fire("session_start", { reason: "startup" });
+			await t.command(command);
+			assert.notEqual(t.ctx.model.provider, "openai-codex-account-2");
+			await t.fire("session_shutdown");
+			assert.deepEqual(t.readState().lastUserModel, t.ctx.model);
+			assert.equal(
+				t.readState().lastUserThinkingLevel,
+				"low",
+				"a manual model choice must not take ownership of thinking",
+			);
+		});
+	}
 });
 
 test("pi-subagents child keeps its explicit launch model and delegates fallback to the parent runner", async () => {

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -276,6 +276,8 @@ function setup(opts: {
 	thinkingLevel?: string;
 	/** Thinking level Pi applies while changing models, before model_select is emitted. */
 	modelSetThinkingLevel?: string;
+	/** Emit setThinkingLevel's fire-and-forget host event, optionally after a prior-handler yield. */
+	thinkingLevelSelectDelivery?: "sync" | "delayed";
 	/** Highest thinking level a provider's models support — Pi clamps anything above it. */
 	thinkingCaps?: Record<string, string>;
 	/** Pi settings.json defaultProvider/defaultModel, used after catalog load. */
@@ -390,6 +392,7 @@ function setup(opts: {
 	const events: Record<string, Array<(event: any, ctx?: any) => any>> = {};
 	const busEvents = new Map<string, Array<(payload: any) => void>>();
 	const commands: Record<string, (args: string, ctx: any) => any> = {};
+	const pendingThinkingLevelSelects: Promise<void>[] = [];
 
 	const ctx: any = {
 		model: opts.current
@@ -497,6 +500,19 @@ function setup(opts: {
 		getContextUsage: () => opts.contextUsage,
 	};
 
+	const dispatchThinkingLevelSelect = (payload: {
+		level: string;
+		previousLevel: string;
+	}) => {
+		const delivery = (async () => {
+			if (opts.thinkingLevelSelectDelivery === "delayed")
+				await Promise.resolve();
+			for (const handler of events.thinking_level_select ?? [])
+				await handler(payload, ctx);
+		})();
+		pendingThinkingLevelSelects.push(delivery);
+	};
+
 	const pi: any = {
 		events: {
 			on: (name: string, handler: (payload: any) => void) => {
@@ -567,7 +583,17 @@ function setup(opts: {
 		getThinkingLevel: () => sessionThinkingLevel,
 		setThinkingLevel: (level: string) => {
 			rec.thinkingLevels.push(level); // what the extension ASKED for
+			const previousLevel = sessionThinkingLevel;
 			sessionThinkingLevel = clampThinking(level); // what the host actually applied
+			if (
+				opts.thinkingLevelSelectDelivery &&
+				sessionThinkingLevel !== previousLevel
+			) {
+				dispatchThinkingLevelSelect({
+					level: sessionThinkingLevel,
+					previousLevel,
+				});
+			}
 		},
 	};
 
@@ -665,6 +691,10 @@ function setup(opts: {
 	const userSetsThinking = (level: string) => {
 		sessionThinkingLevel = clampThinking(level);
 	};
+	const settleThinkingLevelSelects = async () => {
+		while (pendingThinkingLevelSelects.length > 0)
+			await Promise.all(pendingThinkingLevelSelects.splice(0));
+	};
 
 	return {
 		ctx,
@@ -679,6 +709,7 @@ function setup(opts: {
 		input,
 		thinkingLevel,
 		userSetsThinking,
+		settleThinkingLevelSelects,
 		providerConfigs,
 	};
 }
@@ -3072,6 +3103,56 @@ test("explicit CLI thinking wins while ordinary model restoration remains enable
 		id: "claude-opus-4-8",
 	});
 	assert.equal(t.readState().lastUserThinkingLevel, "medium");
+});
+
+test("internal thinking restores do not become explicit CLI intent", async (suite) => {
+	for (const delivery of ["sync", "delayed"] as const) {
+		await suite.test(`${delivery} thinking event delivery`, async () => {
+			const t = setup({
+				accounts: {
+					anthropic: { type: "oauth", access: "a", refresh: "ar" },
+				},
+				current: { provider: "anthropic", id: "claude-opus-4-8" },
+				thinkingLevel: "low",
+				thinkingLevelSelectDelivery: delivery,
+				config: { enabled: false },
+				cliArgs: ["--thinking", "high"],
+				seedState: {
+					stateVersion: 5,
+					lastUserModel: { provider: "anthropic", id: "claude-opus-4-8" },
+					lastUserThinkingLevel: "medium",
+					lastModelByFamily: { anthropic: "claude-opus-4-8" },
+					lastSwitches: [],
+				},
+			});
+			await t.fire("session_start", { reason: "startup" });
+			await t.settleThinkingLevelSelects();
+			assert.equal(t.thinkingLevel(), "high");
+			assert.equal(
+				t.readState().lastUserThinkingLevel,
+				"medium",
+				"the extension's own restore must not persist the one-shot CLI level",
+			);
+
+			// Recreate the exact low -> high event key after the internal event was consumed.
+			t.userSetsThinking("low");
+			await t.fire("thinking_level_select", {
+				level: "low",
+				previousLevel: "high",
+			});
+			t.userSetsThinking("high");
+			await t.fire("thinking_level_select", {
+				level: "high",
+				previousLevel: "low",
+			});
+			await t.fire("session_shutdown");
+			assert.equal(
+				t.readState().lastUserThinkingLevel,
+				"high",
+				"a later genuine identical choice must take ownership of thinking intent",
+			);
+		});
+	}
 });
 
 test("explicit CLI model keeps a native model thinking reset out of remembered state", async () => {


### PR DESCRIPTION
## Summary
- keep explicit `--model` and `--thinking` authoritative after catalog synchronization
- do not let profile or CLI shutdown state overwrite remembered preferences until a genuine user model or thinking selection
- correlate extension-owned thinking restores by model, previous level, and applied level across synchronous and delayed Pi events
- preserve ordinary restoration and passive pi-subagents children

## Verification
- `npm run release:check`
- 473 tests passed
- package and privacy checks passed
- disposable CLI smokes passed for explicit model plus thinking and thinking-only restoration; remembered state stayed unchanged
