### PR TITLE
fix: avoid child-proxy startup deadlock on concurrent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A second concurrent Pi session no longer hangs before it can submit prompts.** When another process owns the canonical child-proxy port, the fallback listener now retries on an ephemeral port on the next event-loop turn and resolves from a standalone `listening` handler. This avoids leaving `session_start` pending forever under Pi's compiled Bun runtime after `EADDRINUSE`.
+
 ## [1.21.1] - 2026-09-03
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -10195,6 +10195,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 		if (slotProxyPort !== undefined) return Promise.resolve(slotProxyPort);
 		if (slotProxyStarting) return slotProxyStarting;
 		slotProxyStarting = new Promise<number | undefined>((resolve) => {
+			let retriedOnEphemeralPort = false;
 			const server = createServer((req, res) => {
 				handleProxyRequest(req, res).catch((error) => {
 					logEvent("slot_proxy_handler_failed", {
@@ -10220,20 +10221,43 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 			// A dead listener must never take Pi down with it — the same rule the Cursor bridge
 			// learned the hard way.
 			server.on("error", (error: NodeJS.ErrnoException) => {
-				if (error.code === "EADDRINUSE" && server.listening === false && !slotProxyPort) {
+				if (
+					error.code === "EADDRINUSE" &&
+					server.listening === false &&
+					!slotProxyPort &&
+					!retriedOnEphemeralPort
+				) {
 					// Another live process owns this port, and with it every route published
 					// against it. We still take an ephemeral port — serving our own in-process
 					// callers costs nothing — but we are no longer the publisher: the shared
 					// files stay exactly as the owner left them. See slotProxyForeignOwner.
+					//
+					// Do not re-enter listen() from the error callback. With an independent
+					// process holding the port, Pi's compiled Bun runtime can leave the server
+					// in its failed-listen transition until the next event-loop turn, so the retry never
+					// reaches the original callback and session_start remains pending forever.
+					retriedOnEphemeralPort = true;
 					slotProxyForeignOwner = true;
 					logEvent("slot_proxy_foreign_owner", { port: SLOT_PROXY_PORT });
-					server.listen(0, "127.0.0.1");
+					setImmediate(() => {
+						try {
+							server.listen(0, "127.0.0.1");
+						} catch (retryError) {
+							logEvent("slot_proxy_listen_failed", {
+								reason: retryError instanceof Error ? retryError.message : String(retryError),
+							});
+							resolve(undefined);
+						}
+					});
 					return;
 				}
 				logEvent("slot_proxy_listen_failed", { reason: error.message });
 				resolve(undefined);
 			});
-			server.listen(SLOT_PROXY_PORT, "127.0.0.1", () => {
+			// Register independently of either listen() attempt. A callback passed only to the
+			// canonical listen can be lost when that attempt emits EADDRINUSE before the server
+			// retries on an ephemeral port.
+			server.once("listening", () => {
 				const address = server.address();
 				slotProxyPort = typeof address === "object" && address ? address.port : undefined;
 				slotProxyServer = server;
@@ -10241,6 +10265,7 @@ export default function piMultiAccount(pi: ExtensionAPI) {
 				logEvent("slot_proxy_listening", { port: slotProxyPort });
 				resolve(slotProxyPort);
 			});
+			server.listen(SLOT_PROXY_PORT, "127.0.0.1");
 		}).finally(() => {
 			slotProxyStarting = undefined;
 		});

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -5,6 +5,7 @@
  * provider responses (possibly retried) -> final assistant message -> agent_end.
  */
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	existsSync,
@@ -9162,6 +9163,46 @@ test("with the proxy off, status warns that the account a bare child picks up is
 	assert.match(status, /openai-codex-account-2/);
 	assert.match(status, /first-available provider/);
 	await t.fire("session_shutdown");
+});
+
+test("a canonical port held by an independent process cannot hang session_start", async () => {
+	// A same-process listener can re-enter listen() synchronously after EADDRINUSE on some Node
+	// versions, which let the ownership test below pass while every second real Pi process hung.
+	// Hold the canonical port from another process to reproduce the actual multi-session boundary.
+	process.env.PI_MULTI_ACCOUNT_SLOT_PROXY_PORT = String(nextSlotProxyPort++);
+	const port = currentSlotProxyPort();
+	const blocker = spawn(
+		process.execPath,
+		[
+			"-e",
+			`require("node:net").createServer().listen(${port}, "127.0.0.1", () => process.stdout.write("ready\\n"))`,
+		],
+		{ stdio: ["ignore", "pipe", "inherit"] },
+	);
+	await new Promise<void>((resolve, reject) => {
+		blocker.once("error", reject);
+		blocker.stdout.once("data", () => resolve());
+	});
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const t = setup({
+			reuseSlotProxyPort: true,
+			current: { provider: "anthropic", id: "claude-opus-4-8" },
+		});
+		await Promise.race([
+			t.fire("session_start"),
+			new Promise((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error("session_start remained pending after EADDRINUSE")),
+					2_000,
+				);
+			}),
+		]);
+		await t.fire("session_shutdown");
+	} finally {
+		if (timer) clearTimeout(timer);
+		blocker.kill();
+	}
 });
 
 test("a second process that cannot own the canonical port leaves the owner's files alone", async () => {


### PR DESCRIPTION
## Summary

- defer the child-proxy ephemeral-port retry until the next event-loop turn after `EADDRINUSE`
- register the `listening` handler independently so either the canonical or fallback listen resolves startup
- bound fallback to one retry and resolve cleanly if the retry throws
- add a concurrent-process regression test and changelog entry

Fixes #42.

## Root cause

When one Pi process already owned the canonical child-proxy port, a second process called `server.listen(0)` synchronously inside the first listen's `error` callback. Pi's compiled Bun runtime could leave that server in its failed-listen transition, and the callback attached only to the original listen was not reached. `startSlotProxy()` therefore remained pending, which kept the awaited `session_start` handler pending and prevented interactive input from being dispatched.

## Validation

- `npm run check`
- `npm run pack:check`
- `npx -y node@24 --test test/*.test.ts` — 497 passed
- targeted concurrent-port tests — passed
- live PTY reproduction against Pi 0.84.4 with an existing process owning the canonical port:
  - upstream 1.21.1: prompt not submitted; final `session_start` event absent
  - patched extension: prompt submitted and agent turn started


---

> **AI disclosure:** This patch and pull request were generated with GPT-5.6 Sol.
