### PR TITLE
fix: preserve user model overrides during slot reprovisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **A second concurrent Pi session no longer hangs before it can submit prompts.** When another process owns the canonical child-proxy port, the fallback listener now retries on an ephemeral port on the next event-loop turn and resolves from a standalone `listening` handler. This avoids leaving `session_start` pending forever under Pi's compiled Bun runtime after `EADDRINUSE`.
+- **Slot provisioning no longer deletes user-authored model metadata.** Existing `modelOverrides` entries — including per-model `contextWindow` and `maxTokens` — now survive startup publication, `/multi-account rediscover`, catalog replacement, and loopback shutdown cleanup. Generated proxy routes are still removed when their owner exits, so preserving the override layer cannot leave a dead port or credential behind.
 
 ## [1.21.1] - 2026-09-03
 

--- a/index.ts
+++ b/index.ts
@@ -59,6 +59,7 @@ import {
 	dropOwnLoopbackPublications,
 	parseProxyPath,
 	placeholderKeyFor,
+	preservedModelOverrides,
 	proxyFamilyFor,
 	publishedRouteFor,
 	shapeUpstreamRequest,
@@ -968,13 +969,6 @@ function nativeModelEntries(models: unknown[]): NativeModelEntry[] {
 function provisionNativeSlot(provider: string, entry: NativeProviderEntry): void {
 	try {
 		const models = nativeModelEntries(entry.models);
-		const normalized: Record<string, unknown> = {
-			api: entry.api,
-			baseUrl: entry.baseUrl,
-			models,
-		};
-		if (entry.apiKey) normalized.apiKey = entry.apiKey;
-		if (entry.compat) normalized.compat = entry.compat;
 		const raw = existsSync(MODELS_CONFIG_PATH)
 			? readFileSync(MODELS_CONFIG_PATH, "utf8")
 			: "{}";
@@ -984,6 +978,15 @@ function provisionNativeSlot(provider: string, entry: NativeProviderEntry): void
 				? parsed.providers
 				: {};
 		const existing = providers[provider];
+		const normalized: Record<string, unknown> = {
+			api: entry.api,
+			baseUrl: entry.baseUrl,
+			models,
+		};
+		if (entry.apiKey) normalized.apiKey = entry.apiKey;
+		if (entry.compat) normalized.compat = entry.compat;
+		const modelOverrides = preservedModelOverrides(existing);
+		if (modelOverrides) normalized.modelOverrides = modelOverrides;
 		if (
 			existing?.baseUrl === normalized.baseUrl &&
 			existing?.api === normalized.api &&

--- a/slot-proxy.ts
+++ b/slot-proxy.ts
@@ -310,8 +310,20 @@ export function isOwnLoopbackPublication(
 	);
 }
 
+/** Return the user-authored model override layer from a provider entry, if present. */
+export function preservedModelOverrides(
+	existing: unknown,
+): Record<string, unknown> | undefined {
+	if (!existing || typeof existing !== "object" || Array.isArray(existing)) return undefined;
+	const overrides = (existing as Record<string, unknown>).modelOverrides;
+	if (!overrides || typeof overrides !== "object" || Array.isArray(overrides)) return undefined;
+	if (Object.keys(overrides).length === 0) return undefined;
+	return overrides as Record<string, unknown>;
+}
+
 /**
- * Drop loopback publications this proxy wrote. Cursor and user entries stay.
+ * Drop loopback publications this proxy wrote. Cursor and user entries stay. A user's
+ * modelOverrides remain as a valid built-in-provider overlay after the generated route is gone.
  * Pass slot ids to drop only those; omit to drop every own loopback (a dead port left behind).
  */
 export function dropOwnLoopbackPublications(
@@ -322,8 +334,10 @@ export function dropOwnLoopbackPublications(
 	const ids = slotIds ?? Object.keys(next);
 	for (const id of ids) {
 		const family = proxyFamilyFor(id);
-		if (!family) continue;
-		if (isOwnLoopbackPublication(next[id], family)) delete next[id];
+		if (!family || !isOwnLoopbackPublication(next[id], family)) continue;
+		const modelOverrides = preservedModelOverrides(next[id]);
+		if (modelOverrides) next[id] = { modelOverrides };
+		else delete next[id];
 	}
 	return next;
 }

--- a/test/failover.test.ts
+++ b/test/failover.test.ts
@@ -9297,6 +9297,57 @@ test("a slot published against a parent-owned loopback route counts as usable", 
 	}
 });
 
+test("user modelOverrides survive proxy publication, rediscovery, and shutdown cleanup", async () => {
+	rmSync(MODELS, { force: true });
+	const modelOverrides = {
+		"claude-opus-5": { contextWindow: 466_384, maxTokens: 64_000 },
+	};
+	writeFileSync(
+		MODELS,
+		JSON.stringify({
+			providers: {
+				anthropic: {
+					api: "anthropic-messages",
+					baseUrl: "https://stale.example.invalid",
+					models: [{ id: "claude-opus-5", contextWindow: 1_000_000 }],
+					modelOverrides,
+				},
+			},
+		}),
+	);
+	const t = setup({
+		current: { provider: "anthropic", id: "claude-opus-5" },
+		accounts: {
+			anthropic: { type: "oauth", access: "a-tok-1", refresh: "a-ref-1" },
+		},
+	});
+	try {
+		await t.fire("session_start");
+		let provider = JSON.parse(readFileSync(MODELS, "utf8")).providers.anthropic;
+		assert.match(provider.baseUrl, /^http:\/\/127\.0\.0\.1:/);
+		assert.deepEqual(provider.modelOverrides, modelOverrides);
+
+		// Force rediscovery to replace stale generated routing/catalog data again. The user's
+		// override layer must survive even when provisioning cannot take its no-op fast path.
+		provider.baseUrl = "https://stale-again.example.invalid";
+		provider.models = [{ id: "claude-opus-5", contextWindow: 1_000_000 }];
+		writeFileSync(MODELS, JSON.stringify({ providers: { anthropic: provider } }));
+		await t.command("rediscover");
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		provider = JSON.parse(readFileSync(MODELS, "utf8")).providers.anthropic;
+		assert.match(provider.baseUrl, /^http:\/\/127\.0\.0\.1:/);
+		assert.deepEqual(provider.modelOverrides, modelOverrides);
+	} finally {
+		await t.fire("session_shutdown");
+	}
+	assert.deepEqual(
+		JSON.parse(readFileSync(MODELS, "utf8")).providers.anthropic,
+		{ modelOverrides },
+		"shutdown must remove the dead loopback route without deleting user model metadata",
+	);
+	rmSync(MODELS, { force: true });
+});
+
 test("with the proxy on, the OAuth slots a child could not use become usable", async () => {
 	// The whole point of the parent-owned route: the slot the rotation chose is the slot the
 	// child runs on, instead of Pi's first-available provider on some other vendor.

--- a/test/slot-proxy.test.ts
+++ b/test/slot-proxy.test.ts
@@ -387,6 +387,22 @@ test("stop drops every own loopback, including numbered slots left on a dead por
 	assert.equal(next.zai, providers.zai);
 });
 
+test("stop removes a dead loopback publication but retains user modelOverrides", () => {
+	const modelOverrides = {
+		"claude-opus-5": { contextWindow: 466_384, maxTokens: 64_000 },
+	};
+	const next = dropOwnLoopbackPublications({
+		anthropic: {
+			api: "anthropic-messages",
+			apiKey: PROXY_PLACEHOLDER_KEY,
+			baseUrl: "http://127.0.0.1:41977/anthropic",
+			models: [{ id: "claude-opus-5", contextWindow: 1_000_000 }],
+			modelOverrides,
+		},
+	});
+	assert.deepEqual(next.anthropic, { modelOverrides });
+});
+
 test("a user's own Anthropic models.json entry is not treated as our loopback", () => {
 	const providers = {
 		anthropic: {


### PR DESCRIPTION
## Summary

- preserve an existing provider's user-authored `modelOverrides` when generated slot routing and model catalogs are replaced
- retain the override-only layer while removing dead loopback routes during shutdown
- cover startup publication, `/multi-account rediscover`, catalog replacement, and shutdown cleanup

Fixes #41.

## Validation

- `npm run release:check` — 499 passed
- `git diff --check`
- verified an override-only Anthropic entry with Pi's `--list-models`: `claude-opus-5` resolves with the configured 466,384-token context window and 64,000 max output tokens
