### PR TITLE
fix: accept native compound tool ids and reasoning summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A Cursor Grok child no longer fails before its first tool runs.** Cursor's OpenAI-compatible adapter composes tool-call identity as `${call_id}\n${item_id}`, joined by one LF rather than the `|` that OpenAI Responses uses. The native controller boundary accepted only the `|` form, so a healthy provider frame was terminated as `malformed_provider_frame (unsupported_tools)` on every attempt and no failover could recover it. Tool-call ids now accept exactly one optional `|`- or LF-joined pair, each half constrained as before and the whole still bounded to 128 characters; tool names, namespaces and route identifiers keep the stricter pattern.
+- **A reasoning-capable Codex child no longer fails on its own reasoning block.** OpenAI Responses streams one reasoning representation and may replace it with a summarized form at `output_item.done`, so requiring the final `thinking_end` content to equal the concatenated deltas rejected a well-formed stream. Reasoning still never crosses the controller boundary and remains bounded by the output cap, but its final value is no longer required to be byte-identical to the streamed deltas.
+- **Malformed-frame terminals now say which frame was rejected.** Block start/delta/end, unsupported stream events and truncated blocks carry distinct fixed reasons instead of one undifferentiated `malformed_provider_frame`, so a live failure names its own cause.
+
 ## [1.21.2] - 2026-09-04
 
 ### Fixed

--- a/controller-provider.ts
+++ b/controller-provider.ts
@@ -16,9 +16,10 @@ const ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const PROVIDER_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const MODEL_ID = /^[A-Za-z0-9~][A-Za-z0-9._/:~-]{0,159}$/;
 const PROVIDER_REASON = /^[a-z_]{1,64}$/;
-// OpenAI Responses composes tool ids as `${call_id}|${item.id}`. Keep the
-// delimiter scoped to tool-call ids; route/snapshot identifiers remain stricter.
-const TOOL_CALL_ID = /^(?=.{1,128}$)[A-Za-z0-9][A-Za-z0-9._:-]*(?:\|[A-Za-z0-9][A-Za-z0-9._:-]*)?$/;
+// Native providers expose compound tool ids in two observed forms: OpenAI Responses joins
+// `${call_id}|${item.id}`, while Cursor's Grok SSE adapter joins the same two bounded components
+// with one LF. Keep both delimiters scoped to tool-call ids; route/snapshot ids stay stricter.
+const TOOL_CALL_ID = /^(?=[\s\S]{1,128}$)[A-Za-z0-9][A-Za-z0-9._:-]*(?:(?:\||\n)[A-Za-z0-9][A-Za-z0-9._:-]*)?$/;
 const TOOL_NAME = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
 const ROUTE_CACHE_LIMIT = 256;
 const ROUTE_CACHE_TTL_MS = 10 * 60 * 1000;
@@ -27,6 +28,11 @@ const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhi
 
 const FIXED_REASONS = Object.freeze({
 	unsupportedTools: "unsupported_tools",
+	invalidBlockStart: "invalid_block_start",
+	invalidBlockDelta: "invalid_block_delta",
+	invalidBlockEnd: "invalid_block_end",
+	unsupportedStreamEvent: "unsupported_stream_event",
+	truncatedBlock: "truncated_block",
 	invalidModel: "invalid_model",
 	invalidRequest: "invalid_request",
 	contextWindow: "context_window_exceeded",
@@ -540,7 +546,7 @@ export function createControllerProvider({
 						const blockType = blockTypeFor(type);
 						if (!Number.isSafeInteger(index) || index < 0 || !blockType || openBlocks.has(index)) {
 							terminalSeen = true;
-							yield terminal("malformed_provider_frame");
+							yield terminal("malformed_provider_frame", FIXED_REASONS.invalidBlockStart);
 							return;
 						}
 						openBlocks.set(index, { type: blockType, value: "", bytes: 0 });
@@ -554,7 +560,7 @@ export function createControllerProvider({
 						const expected = type === "text_delta" ? "text" : "reasoning";
 						if (!block || block.type !== expected || typeof event.delta !== "string" || event.delta.length === 0) {
 							terminalSeen = true;
-							yield terminal("malformed_provider_frame");
+							yield terminal("malformed_provider_frame", FIXED_REASONS.invalidBlockDelta);
 							return;
 						}
 						const bytes = Buffer.byteLength(event.delta, "utf8");
@@ -574,9 +580,15 @@ export function createControllerProvider({
 						const index = event.contentIndex;
 						const block = openBlocks.get(index);
 						const expected = type === "text_end" ? "text" : "reasoning";
-						if (!block || block.type !== expected || typeof event.content !== "string" || event.content !== block.value) {
+						const contentBytes = typeof event.content === "string" ? Buffer.byteLength(event.content, "utf8") : Infinity;
+						// OpenAI Responses streams one reasoning representation, then may replace it with
+						// a summarized form at output_item.done. Reasoning never crosses this controller
+						// boundary, so validate/bound the final value but do not require byte equality.
+						const contentMatches = expected === "reasoning" || event.content === block?.value;
+						if (!block || block.type !== expected || typeof event.content !== "string"
+							|| contentBytes > snapshot.maxOutputBytes || !contentMatches) {
 							terminalSeen = true;
-							yield terminal("malformed_provider_frame");
+							yield terminal("malformed_provider_frame", FIXED_REASONS.invalidBlockEnd);
 							return;
 						}
 						openBlocks.delete(index);
@@ -666,7 +678,7 @@ export function createControllerProvider({
 					if (type === "done") {
 						if (openBlocks.size > 0) {
 							terminalSeen = true;
-							yield terminal("stream_truncated");
+							yield terminal("stream_truncated", FIXED_REASONS.truncatedBlock);
 							return;
 						}
 						const usage = usageFrom(event.message?.usage);
@@ -694,7 +706,7 @@ export function createControllerProvider({
 						}
 						return;
 					}
-					yield terminal("malformed_provider_frame");
+					yield terminal("malformed_provider_frame", FIXED_REASONS.unsupportedStreamEvent);
 					return;
 				}
 				if (!terminalSeen) {

--- a/test/controller-provider.test.ts
+++ b/test/controller-provider.test.ts
@@ -200,8 +200,9 @@ test("native transport consumes provider reasoning without widening the text-onl
 		events: [
 			{ type: "start", partial: {} },
 			{ type: "thinking_start", contentIndex: 0, partial: {} },
-			{ type: "thinking_delta", contentIndex: 0, delta: "private", partial: {} },
-			{ type: "thinking_end", contentIndex: 0, content: "private", partial: {} },
+			{ type: "thinking_delta", contentIndex: 0, delta: "private streamed reasoning", partial: {} },
+			// OpenAI Responses may replace streamed reasoning with its final summary at item.done.
+			{ type: "thinking_end", contentIndex: 0, content: "final reasoning summary", partial: {} },
 			{ type: "text_start", contentIndex: 1, partial: {} },
 			{ type: "text_delta", contentIndex: 1, delta: "answer", partial: {} },
 			{ type: "text_end", contentIndex: 1, content: "answer", partial: {} },
@@ -281,6 +282,36 @@ test("native transport forwards tool schemas and Codex compound tool-call ids wi
 		{ type: "usage", payload: { input: 4, output: 3, cacheRead: 0, cacheWrite: 0 } },
 		{ type: "terminal", outcome: "succeeded_terminal", payload: { httpStatus: 200, providerRequestId: "req-1", finishReason: "tool_use" } },
 	]);
+});
+
+test("Cursor Grok forwards its LF-joined compound tool-call id", async () => {
+	const currentModel = model("cursor", "cursor-grok-4.6", "openai-completions");
+	const toolCallId = "call-12345678-1234-1234-1234-123456789abc-1\nfc_12345678-1234-1234-1234-123456789abc_0";
+	const { registry } = makeRegistry([currentModel], {
+		events: [
+			{ type: "start", partial: {} },
+			{ type: "toolcall_start", contentIndex: 0, partial: {} },
+			{ type: "toolcall_delta", contentIndex: 0, delta: '{"path":"README.md"}', partial: {} },
+			{ type: "toolcall_end", contentIndex: 0, toolCall: { type: "toolCall", id: toolCallId, name: "read", arguments: { path: "README.md" } }, partial: {} },
+			{ type: "done", reason: "toolUse", message: { content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "README.md" } }], usage: { input: 8, output: 4 } } },
+		],
+	});
+	const pair = createControllerProvider({ modelRegistry: registry });
+	const currentLease = lease("lease-cursor-grok-tool", currentModel.provider, currentModel.id);
+	const route = await pair.routeResolver(currentLease);
+	const output = [];
+	for await (const event of pair.providerTransport.stream(snapshot(route, currentLease), {
+		messages: [{ role: "user", content: "read README.md" }],
+		tools: [{ name: "read", description: "read", inputSchema: {} }],
+	})) output.push(event);
+	assert.deepEqual(output.slice(1, 4), [
+		{ type: "block_start", payload: { index: 0, blockType: "tool_call", id: toolCallId, name: "read" } },
+		{ type: "tool_call_delta", payload: { index: 0, delta: '{"path":"README.md"}' } },
+		{ type: "block_end", payload: { index: 0, value: '{"path":"README.md"}' } },
+	]);
+	const finalEvent = output.at(-1);
+	assert.equal(finalEvent?.type, "terminal");
+	if (finalEvent?.type === "terminal") assert.equal(finalEvent.outcome, "succeeded_terminal");
 });
 
 test("routeResolver fails closed when Pi cannot resolve an exact model credential", async () => {


### PR DESCRIPTION
## Summary

Two live delegation failures observed today, both on healthy routes and both fatal before any tool ran:

- Cursor Grok composes tool-call identity as `${call_id}\n${item_id}` (LF), not the `|` used by OpenAI Responses. The `|`-only rule rejected a valid frame as `malformed_provider_frame (unsupported_tools)`.
- OpenAI Responses may replace streamed reasoning with a summarized form at `output_item.done`. Requiring `thinking_end` to equal the concatenated deltas rejected a well-formed Codex stream as `malformed_provider_frame`.

Malformed-frame terminals now carry distinct fixed reasons, so the next such failure names its own cause instead of collapsing to one opaque code.

## Boundary

Reasoning still never crosses the controller boundary and stays bounded by the output cap. Tool names, namespaces and route identifiers keep the stricter pattern; only tool-call ids admit one optional `|`/LF-joined pair within the existing 128-character bound.

## Verification

- `npm run release:check`: 500/500 tests, package and tracked-privacy checks pass
- live fresh-process canary on exact route `openai-codex-account-4/gpt-5.6-sol`: real `read` tool turn returned `CODEX_TOOL_OK`
- live fresh-process canary on exact route `cursor/cursor-grok-4.6`: real `read` tool turn returned `GROK_TOOL_OK`
